### PR TITLE
feat(context-panel): add side-panel quote popup for assistant response text

### DIFF
--- a/addon/content/zoteroPane.css
+++ b/addon/content/zoteroPane.css
@@ -292,63 +292,37 @@
   -moz-appearance: none;
   position: absolute;
   z-index: 8;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: calc(24px * var(--llm-font-scale, 1));
-  padding: calc(4px * var(--llm-font-scale, 1))
-    calc(10px * var(--llm-font-scale, 1));
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--stroke-secondary) 70%, transparent);
-  background: color-mix(in srgb, var(--material-background) 88%, transparent);
+  background: var(--material-background);
+  border-color: var(--stroke-secondary);
   color: var(--fill-primary);
-  font-size: var(--llm-fs-11);
-  font-weight: 500;
-  line-height: 1.2;
-  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.14);
-  backdrop-filter: blur(2px);
+  width: auto;
+  max-width: none;
+  margin: 0;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transform: translateY(4px) scale(0.985);
+  transform: translateY(4px);
   will-change: opacity, transform;
   transition:
     opacity 140ms ease,
     transform 140ms ease,
-    visibility 140ms ease,
-    background-color 140ms ease,
-    border-color 140ms ease,
-    box-shadow 140ms ease;
+    visibility 140ms ease;
 }
 
 .llm-assistant-selection-action.is-visible {
   opacity: 1;
   visibility: visible;
-  transform: translateY(0) scale(1);
+  transform: translateY(0);
   pointer-events: auto;
 }
 
-.llm-assistant-selection-action:hover {
-  border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
-  background: color-mix(in srgb, var(--material-background) 78%, #000);
-  box-shadow: 0 5px 11px rgba(0, 0, 0, 0.18);
-  transform: translateY(-0.8px) scale(1.008);
-}
-
-.llm-assistant-selection-action:active {
-  background: color-mix(in srgb, var(--material-background) 76%, #000);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
-  transform: translateY(0) scale(0.992);
-}
-
-@media (prefers-color-scheme: light) {
-  .llm-assistant-selection-action:hover {
-    background: #f2f2f2;
-  }
-
-  .llm-assistant-selection-action:active {
-    background: #eaeaea;
-  }
+.llm-assistant-selection-action:hover:not(:disabled),
+.llm-assistant-selection-action:active:not(:disabled),
+.llm-assistant-selection-action:focus-visible {
+  background: var(--material-background);
+  border-color: var(--stroke-secondary);
+  color: var(--fill-primary);
 }
 
 /* Welcome Message */

--- a/src/modules/contextPanel/setupHandlers.ts
+++ b/src/modules/contextPanel/setupHandlers.ts
@@ -273,7 +273,7 @@ export function setupHandlers(body: Element, item?: Zotero.Item | null) {
   const selectionPopup = createElement(
     panelDoc,
     "button",
-    "llm-assistant-selection-action",
+    "llm-shortcut-btn llm-assistant-selection-action",
     {
       type: "button",
       textContent: "❞ Quote",
@@ -439,6 +439,12 @@ export function setupHandlers(body: Element, item?: Zotero.Item | null) {
 
   const onPanelMouseUp = (e: Event) => {
     if (!panelWin) return;
+    const me = e as MouseEvent;
+    if (typeof me.button === "number" && me.button !== 0) {
+      selectionDragStartBubble = null;
+      hideSelectionPopup();
+      return;
+    }
     const target = e.target as Element | null;
     const bubble = target?.closest(".llm-bubble.assistant") as HTMLElement | null;
     const fallbackBubble = bubble || selectionDragStartBubble;
@@ -469,6 +475,7 @@ export function setupHandlers(body: Element, item?: Zotero.Item | null) {
   selectionPopup.addEventListener("contextmenu", (e: Event) => {
     e.preventDefault();
     e.stopPropagation();
+    hideSelectionPopup();
   });
 
   panelDoc.addEventListener("mouseup", onPanelMouseUp, true);


### PR DESCRIPTION
This PR is a focused split from #23, containing only the side-panel text-selection quote flow.

### Included
- Adds a contextual `Quote` popup when selecting assistant response text in the side panel.
- Clicking `Quote` adds selected text to **Text Context** (same flow as `Add Text`).
- Popup placement is anchored near the last-selected endpoint.
- Includes edge-case handling when drag-select starts in a bubble and mouse-up happens outside.
- Keeps compatibility with existing right-click actions (`Copy` / `Save as note`).

### Demo
![CleanShot 2026-02-19 at 16 17 13](https://github.com/user-attachments/assets/9c2375d7-8e08-457d-9655-828967c558e2)

This PR is intentionally scoped for easier review/merge.