### PR TITLE
feat: add 11 new LLM provider presets for domestic and international …

### DIFF
--- a/src/utils/modelInputCap.ts
+++ b/src/utils/modelInputCap.ts
@@ -88,6 +88,51 @@ const MODEL_INPUT_LIMIT_RULES: ModelInputLimitRule[] = [
   // DeepSeek
   { pattern: /^deepseek-(?:chat|reasoner)(?:[.-]|$)/, limit: 128_000 },
   { pattern: /^deepseek(?:[.-]|$)/, limit: 128_000 },
+
+  // Yi (01.AI)
+  { pattern: /^yi-(?:large|medium|light)(?:[.-]|$)/, limit: 16_384 },
+  { pattern: /^yi-vision(?:[.-]|$)/, limit: 16_384 },
+  { pattern: /^yi-large-rag(?:[.-]|$)/, limit: 16_384 },
+  { pattern: /^yi-large-turbo(?:[.-]|$)/, limit: 16_384 },
+  { pattern: /^yi(?:[.-]|$)/, limit: 16_384 },
+
+  // Hunyuan (Tencent)
+  { pattern: /^hunyuan-(?:pro|standard|lite|turbo)(?:[.-]|$)/, limit: 32_000 },
+  { pattern: /^hunyuan(?:[.-]|$)/, limit: 32_000 },
+
+  // Spark (iFlytek)
+  { pattern: /^general(?:v3|v3[.-]5|v4[.-]0)?(?:[.-]|$)/, limit: 131_072 },
+  { pattern: /^spark(?:[.-]|$)/, limit: 131_072 },
+
+  // Baichuan
+  { pattern: /^baichuan4(?:[.-]|$)/, limit: 32_768 },
+  { pattern: /^baichuan3-turbo(?:[.-]|$)/, limit: 32_768 },
+  { pattern: /^baichuan(?:[.-]|$)/, limit: 32_768 },
+
+  // StepFun
+  { pattern: /^step-1(?:[.-]|$)/, limit: 16_384 },
+  { pattern: /^step-2(?:[.-]|$)/, limit: 65_536 },
+  { pattern: /^step(?:[.-]|$)/, limit: 16_384 },
+
+  // 360AI
+  { pattern: /^360gpt(?:[.-]|$)/, limit: 16_384 },
+  { pattern: /^360(?:[.-]|$)/, limit: 16_384 },
+
+  // Common open-source models (served via OpenRouter, SiliconFlow, Together, Groq, etc.)
+  { pattern: /^llama-3(?:[.-]|$)/, limit: 131_072 },
+  { pattern: /^llama-2(?:[.-]|$)/, limit: 4_096 },
+  { pattern: /^llama(?:[.-]|$)/, limit: 131_072 },
+  { pattern: /^mixtral-8x7b(?:[.-]|$)/, limit: 32_768 },
+  { pattern: /^mixtral-8x22b(?:[.-]|$)/, limit: 65_536 },
+  { pattern: /^mixtral(?:[.-]|$)/, limit: 32_768 },
+  { pattern: /^gemma-2(?:[.-]|$)/, limit: 8_192 },
+  { pattern: /^gemma(?:[.-]|$)/, limit: 8_192 },
+  { pattern: /^phi-3(?:[.-]|$)/, limit: 128_000 },
+  { pattern: /^phi(?:[.-]|$)/, limit: 128_000 },
+  { pattern: /^internlm(?:[.-]|$)/, limit: 32_768 },
+  { pattern: /^dbrx(?:[.-]|$)/, limit: 32_768 },
+  { pattern: /^qwen2(?:[.-]|$)/, limit: 131_072 },
+  { pattern: /^qwen2\.5(?:[.-]|$)/, limit: 131_072 },
 ];
 
 function stripTrailingNotice(text: string, notice: string): string {

--- a/src/utils/modelProviders.ts
+++ b/src/utils/modelProviders.ts
@@ -197,6 +197,16 @@ export function deriveProviderLabel(
   if (lowerHost.includes("dashscope") || lowerHost.includes("aliyuncs.com")) {
     return "Qwen";
   }
+  if (lowerHost.includes("siliconflow")) return "SiliconFlow";
+  if (lowerHost.includes("xf-yun.com")) return "Spark";
+  if (lowerHost.includes("hunyuan") || lowerHost.includes("tencent.com")) {
+    return "Hunyuan";
+  }
+  if (lowerHost.includes("baichuan")) return "Baichuan";
+  if (lowerHost.includes("stepfun")) return "StepFun";
+  if (lowerHost.includes("lingyiwanwu")) return "Yi";
+  if (lowerHost.includes("fireworks.ai")) return "Fireworks AI";
+  if (lowerHost.includes("mistral.ai")) return "Mistral";
 
   return host;
 }

--- a/src/utils/providerPresets.ts
+++ b/src/utils/providerPresets.ts
@@ -10,7 +10,20 @@ export type SupportedProviderPresetId =
   | "grok"
   | "qwen"
   | "kimi"
-  | "copilot";
+  | "copilot"
+  // Domestic (China)
+  | "siliconflow"
+  | "spark"
+  | "hunyuan"
+  | "baichuan"
+  | "stepfun"
+  | "yi"
+  // International
+  | "openrouter"
+  | "together"
+  | "groq"
+  | "mistral"
+  | "fireworks";
 
 export type ProviderPresetId = SupportedProviderPresetId | "customized";
 
@@ -113,6 +126,17 @@ const QWEN_PATHS = [
 ];
 const KIMI_PATHS = ["/", "/v1", "/v1/chat/completions"];
 const COPILOT_PATHS = ["/", "/chat/completions", "/models"];
+const SILICONFLOW_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const SPARK_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const HUNYUAN_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const BAICHUAN_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const STEPFUN_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const YI_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const OPENROUTER_PATHS = ["/", "/api/v1", "/api/v1/chat/completions"];
+const TOGETHER_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const GROQ_PATHS = ["/", "/openai/v1", "/openai/v1/chat/completions"];
+const MISTRAL_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const FIREWORKS_PATHS = ["/", "/inference/v1", "/inference/v1/chat/completions"];
 
 export const PROVIDER_PRESETS: ProviderPreset[] = [
   {
@@ -227,6 +251,140 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     matches: makeHostAndPathMatcher(
       ["api.githubcopilot.com"],
       COPILOT_PATHS,
+    ),
+  },
+  // --- Domestic (China) ---
+  {
+    id: "siliconflow",
+    label: "SiliconFlow",
+    defaultApiBase: "https://api.siliconflow.cn/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses SiliconFlow's official API (aggregates open-source models).",
+    matches: makeHostAndPathMatcher(
+      ["api.siliconflow.cn", "api.siliconflow.com"],
+      SILICONFLOW_PATHS,
+    ),
+  },
+  {
+    id: "spark",
+    label: "Spark",
+    defaultApiBase: "https://spark-api-open.xf-yun.com/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses iFlytek Spark's OpenAI-compatible API.",
+    matches: makeHostAndPathMatcher(
+      ["spark-api-open.xf-yun.com"],
+      SPARK_PATHS,
+    ),
+  },
+  {
+    id: "hunyuan",
+    label: "Hunyuan",
+    defaultApiBase: "https://api.hunyuan.cloud.tencent.com/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses Tencent Hunyuan's official API.",
+    matches: makeHostAndPathMatcher(
+      ["api.hunyuan.cloud.tencent.com", "hunyuan.cloud.tencent.com"],
+      HUNYUAN_PATHS,
+    ),
+  },
+  {
+    id: "baichuan",
+    label: "Baichuan",
+    defaultApiBase: "https://api.baichuan-ai.com/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses Baichuan AI's official API.",
+    matches: makeHostAndPathMatcher(
+      ["api.baichuan-ai.com"],
+      BAICHUAN_PATHS,
+    ),
+  },
+  {
+    id: "stepfun",
+    label: "StepFun",
+    defaultApiBase: "https://api.stepfun.com/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses StepFun's official API.",
+    matches: makeHostAndPathMatcher(
+      ["api.stepfun.com"],
+      STEPFUN_PATHS,
+    ),
+  },
+  {
+    id: "yi",
+    label: "Yi",
+    defaultApiBase: "https://api.lingyiwanwu.com/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses 01.AI (Yi) official API.",
+    matches: makeHostAndPathMatcher(
+      ["api.lingyiwanwu.com"],
+      YI_PATHS,
+    ),
+  },
+  // --- International ---
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    defaultApiBase: "https://openrouter.ai/api/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses OpenRouter's API (aggregates many model providers).",
+    matches: makeHostAndPathMatcher(
+      ["openrouter.ai"],
+      OPENROUTER_PATHS,
+    ),
+  },
+  {
+    id: "together",
+    label: "Together.ai",
+    defaultApiBase: "https://api.together.xyz/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses Together.ai's API (open-source models).",
+    matches: makeHostAndPathMatcher(
+      ["api.together.xyz"],
+      TOGETHER_PATHS,
+    ),
+  },
+  {
+    id: "groq",
+    label: "Groq",
+    defaultApiBase: "https://api.groq.com/openai/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses Groq's ultra-fast inference API.",
+    matches: makeHostAndPathMatcher(
+      ["api.groq.com"],
+      GROQ_PATHS,
+    ),
+  },
+  {
+    id: "mistral",
+    label: "Mistral",
+    defaultApiBase: "https://api.mistral.ai/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses Mistral AI's official API.",
+    matches: makeHostAndPathMatcher(
+      ["api.mistral.ai"],
+      MISTRAL_PATHS,
+    ),
+  },
+  {
+    id: "fireworks",
+    label: "Fireworks AI",
+    defaultApiBase: "https://api.fireworks.ai/inference/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText: "Preset uses Fireworks AI's inference API.",
+    matches: makeHostAndPathMatcher(
+      ["api.fireworks.ai"],
+      FIREWORKS_PATHS,
     ),
   },
 ];


### PR DESCRIPTION
…providers

Add preset configurations for commonly used LLM providers so users only need to fill in API key:

Domestic (China):
- SiliconFlow (硅基流动) - api.siliconflow.cn
- Spark (讯飞星火) - spark-api-open.xf-yun.com
- Hunyuan (腾讯混元) - api.hunyuan.cloud.tencent.com
- Baichuan (百川智能) - api.baichuan-ai.com
- StepFun (阶跃星辰) - api.stepfun.com
- Yi (零一万物) - api.lingyiwanwu.com

International:
- OpenRouter - openrouter.ai/api/v1
- Together.ai - api.together.xyz
- Groq - api.groq.com
- Mistral - api.mistral.ai
- Fireworks AI - api.fireworks.ai

Also added model input token cap rules for models commonly served through these providers.