### PR TITLE
feat: add skills management portal in standalone window

### DIFF
--- a/addon/content/icons/action-skill.svg
+++ b/addon/content/icons/action-skill.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20h9"/>
+  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/>
+</svg>

--- a/addon/content/zoteroPane.css
+++ b/addon/content/zoteroPane.css
@@ -757,6 +757,12 @@
   -webkit-mask-image: url("icons/action-settings.svg");
 }
 
+/* Skill icon — pen/edit */
+.llm-standalone-icon-skill::before {
+  mask-image: url("icons/action-skill.svg");
+  -webkit-mask-image: url("icons/action-skill.svg");
+}
+
 /* Export icon — download */
 .llm-standalone-icon-export::before {
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4'/%3E%3Cpolyline points='7 10 12 15 17 10'/%3E%3Cline x1='12' y1='15' x2='12' y2='3'/%3E%3C/svg%3E");
@@ -980,6 +986,159 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* ── Skills popup ─────────────────────────────────────────────── */
+.llm-standalone-skill-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: rgba(0, 0, 0, 0.35);
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.llm-standalone-skill-popup {
+  display: flex;
+  flex-direction: column;
+  width: min(90%, 520px);
+  max-height: 60vh;
+  background: color-mix(in srgb, var(--material-background) 96%, black 4%);
+  border: 1px solid var(--stroke-secondary);
+  border-radius: 10px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+  overflow: hidden;
+}
+
+.llm-standalone-skill-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--stroke-secondary);
+}
+
+.llm-standalone-skill-title {
+  flex: 1;
+  font-size: var(--llm-fs-14, 14px);
+  font-weight: 600;
+  color: var(--fill-primary);
+}
+
+.llm-standalone-skill-grid {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 12px;
+}
+
+.llm-standalone-skill-item {
+  appearance: none;
+  -moz-appearance: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 6px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--fill-primary);
+  transition: background 0.12s;
+}
+
+.llm-standalone-skill-item:hover {
+  background: var(--fill-quinary);
+}
+
+.llm-standalone-skill-label {
+  font-size: var(--llm-fs-11, 11px);
+  color: var(--fill-secondary);
+  text-align: center;
+  word-break: break-all;
+  line-height: 1.3;
+  max-width: 100%;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+/* Document icon — CSS mask for grid items */
+.llm-standalone-skill-doc-icon {
+  display: block;
+  width: 32px;
+  height: 32px;
+  background-color: var(--fill-secondary);
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3Cline x1='16' y1='13' x2='8' y2='13'/%3E%3Cline x1='16' y1='17' x2='8' y2='17'/%3E%3Cline x1='10' y1='9' x2='8' y2='9'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3Cline x1='16' y1='13' x2='8' y2='13'/%3E%3Cline x1='16' y1='17' x2='8' y2='17'/%3E%3Cline x1='10' y1='9' x2='8' y2='9'/%3E%3C/svg%3E");
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+}
+
+/* "+" add button — first grid item */
+.llm-standalone-skill-add {
+  border: 1px dashed var(--stroke-secondary);
+}
+.llm-standalone-skill-add:hover {
+  border-color: var(--fill-tertiary);
+}
+.llm-standalone-skill-add-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  font-size: 24px;
+  font-weight: 300;
+  color: var(--fill-tertiary);
+  line-height: 1;
+}
+
+/* Context menu */
+.llm-standalone-skill-ctx-menu {
+  display: none;
+  position: fixed;
+  z-index: 40;
+  flex-direction: column;
+  min-width: 160px;
+  background: color-mix(in srgb, var(--material-background) 96%, black 4%);
+  border: 1px solid var(--stroke-secondary);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  padding: 4px 0;
+  overflow: hidden;
+}
+
+.llm-standalone-skill-ctx-item {
+  appearance: none;
+  -moz-appearance: none;
+  display: block;
+  width: 100%;
+  padding: 7px 12px;
+  border: none;
+  background: transparent;
+  color: var(--fill-primary);
+  font: inherit;
+  font-size: var(--llm-fs-12, 12px);
+  text-align: left;
+  cursor: pointer;
+}
+
+.llm-standalone-skill-ctx-item:hover {
+  background: var(--fill-quinary);
+}
+
+.llm-standalone-skill-ctx-delete {
+  color: #d32f2f;
 }
 
 /* Panel — expandable conversation list */

--- a/src/agent/skills/index.ts
+++ b/src/agent/skills/index.ts
@@ -6,15 +6,14 @@
  * instruction is injected into the agent system prompt alongside tool
  * guidances.
  *
- * To add a new skill:
- * 1. Create a `.md` file in this directory (use existing skills as templates).
- * 2. Import it below and add it to the BUILTIN_SKILLS array.
+ * Built-in skills are bundled at compile time and copied to the user's
+ * data directory on first run. The user folder is the sole source of
+ * truth — the agent reads only from there.
  *
- * Users can also add custom skills by placing `.md` files in:
+ * Users can create, edit, or delete skills by managing `.md` files in:
  *   {Zotero data directory}/llm-for-zotero/skills/
- * These are loaded at runtime via loadUserSkills().
  */
-import { parseSkill, matchesSkill } from "./skillLoader";
+import { matchesSkill } from "./skillLoader";
 import type { AgentSkill } from "./skillLoader";
 import libraryAnalysisRaw from "./library-analysis.md";
 import comparePapersRaw from "./compare-papers.md";
@@ -29,42 +28,43 @@ import writeToObsidianRaw from "./write-to-obsidian.md";
 export { matchesSkill } from "./skillLoader";
 export type { AgentSkill } from "./skillLoader";
 
-/** Built-in skills bundled at compile time. */
-const BUILTIN_SKILLS: AgentSkill[] = [
-  parseSkill(libraryAnalysisRaw),
-  parseSkill(comparePapersRaw),
-  parseSkill(analyzeFiguresRaw),
-  parseSkill(simplePaperQaRaw),
-  parseSkill(evidenceBasedQaRaw),
-  parseSkill(noteFromPaperRaw),
-  parseSkill(noteEditingRaw),
-  parseSkill(literatureReviewRaw),
-  parseSkill(writeToObsidianRaw),
-];
-
-/** User-defined skills loaded at runtime from the data directory. */
-let userSkills: AgentSkill[] = [];
+/**
+ * Built-in skill files bundled at compile time.
+ * Used by initUserSkills() to copy defaults to the user folder.
+ */
+export const BUILTIN_SKILL_FILES: Record<string, string> = {
+  "library-analysis.md": libraryAnalysisRaw,
+  "compare-papers.md": comparePapersRaw,
+  "analyze-figures.md": analyzeFiguresRaw,
+  "simple-paper-qa.md": simplePaperQaRaw,
+  "evidence-based-qa.md": evidenceBasedQaRaw,
+  "note-from-paper.md": noteFromPaperRaw,
+  "note-editing.md": noteEditingRaw,
+  "literature-review.md": literatureReviewRaw,
+  "write-to-obsidian.md": writeToObsidianRaw,
+};
 
 /**
- * Replace the current set of user-defined skills.
+ * Skills loaded from the user's data directory.
+ * This is the sole source of truth — the agent reads only from here.
+ */
+let skills: AgentSkill[] = [];
+
+/**
+ * Replace the current set of skills.
  * Called once at plugin startup after scanning the user skills directory.
  */
-export function setUserSkills(skills: AgentSkill[]): void {
-  userSkills = skills;
+export function setUserSkills(loaded: AgentSkill[]): void {
+  skills = loaded;
 }
 
 /**
- * Returns all skills (built-in + user-defined).
+ * Returns all skills loaded from the user folder.
  * This is the primary accessor used by messageBuilder and trace events.
  */
 export function getAllSkills(): AgentSkill[] {
-  return [...BUILTIN_SKILLS, ...userSkills];
+  return skills;
 }
-
-/**
- * @deprecated Use {@link getAllSkills} instead. Kept for backward compatibility.
- */
-export const AGENT_SKILLS = BUILTIN_SKILLS;
 
 /**
  * Returns the IDs of all skills whose patterns match the request.

--- a/src/agent/skills/userSkills.ts
+++ b/src/agent/skills/userSkills.ts
@@ -1,12 +1,13 @@
 /**
- * User-defined skills — runtime loading from the Zotero data directory.
+ * Skills — runtime loading from the Zotero data directory.
  *
- * Users can place `.md` skill files (same frontmatter format as built-in
- * skills) in `{Zotero data directory}/llm-for-zotero/skills/`. These are
- * loaded once at startup and merged with built-in skills.
+ * The user's skills directory is the sole source of truth. Built-in skills
+ * are copied there on first run (or when new ones are added in updates).
+ * Users can create, edit, or delete `.md` skill files freely.
  */
 import { parseSkill } from "./skillLoader";
 import type { AgentSkill } from "./skillLoader";
+import { BUILTIN_SKILL_FILES } from "./index";
 
 const USER_SKILLS_DIR_NAME = "llm-for-zotero/skills";
 
@@ -21,11 +22,13 @@ type PathUtilsLike = {
 type IOUtilsLike = {
   exists?: (path: string) => Promise<boolean>;
   read?: (path: string) => Promise<Uint8Array | ArrayBuffer>;
+  write?: (path: string, data: Uint8Array) => Promise<number>;
   makeDirectory?: (
     path: string,
     options?: { createAncestors?: boolean; ignoreExisting?: boolean },
   ) => Promise<void>;
   getChildren?: (path: string) => Promise<string[]>;
+  remove?: (path: string) => Promise<void>;
 };
 
 function getPathUtils(): PathUtilsLike | undefined {
@@ -68,11 +71,59 @@ export function getUserSkillsDir(): string {
 }
 
 // ---------------------------------------------------------------------------
+// Initialization — copy missing built-in skills to user folder
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure the user skills directory exists and contains all built-in skills.
+ * Missing built-in files are copied; existing files are never overwritten.
+ * Call this before loadUserSkills().
+ */
+export async function initUserSkills(): Promise<void> {
+  const io = getIOUtils();
+  if (!io?.exists || !io?.write || !io?.makeDirectory) return;
+
+  const dir = getUserSkillsDir();
+
+  try {
+    const exists = await io.exists(dir);
+    if (!exists) {
+      await io.makeDirectory(dir, {
+        createAncestors: true,
+        ignoreExisting: true,
+      });
+    }
+  } catch {
+    return;
+  }
+
+  const encoder = new TextEncoder();
+
+  for (const [filename, content] of Object.entries(BUILTIN_SKILL_FILES)) {
+    const filePath = joinPath(dir, filename);
+    try {
+      const exists = await io.exists(filePath);
+      if (!exists) {
+        await io.write(filePath, encoder.encode(content));
+        Zotero.debug?.(
+          `[llm-for-zotero] Copied built-in skill to user folder: ${filename}`,
+        );
+      }
+    } catch (err) {
+      Zotero.debug?.(
+        `[llm-for-zotero] Failed to copy built-in skill ${filename}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Loading
 // ---------------------------------------------------------------------------
 
 /**
  * Scan the user skills directory for `.md` files and parse them.
+ * This is the sole source of skills — all skills come from the user folder.
  * Returns an empty array if the directory does not exist or no valid
  * skill files are found. Never throws.
  */
@@ -82,18 +133,9 @@ export async function loadUserSkills(): Promise<AgentSkill[]> {
 
   const dir = getUserSkillsDir();
 
-  // Ensure directory exists (create it on first run so users know where to put files)
   try {
     const exists = await io.exists(dir);
-    if (!exists) {
-      if (io.makeDirectory) {
-        await io.makeDirectory(dir, {
-          createAncestors: true,
-          ignoreExisting: true,
-        });
-      }
-      return [];
-    }
+    if (!exists) return [];
   } catch {
     return [];
   }
@@ -123,26 +165,105 @@ export async function loadUserSkills(): Promise<AgentSkill[]> {
       // Validate: must have a real id and at least one pattern
       if (skill.id === "unknown" || skill.patterns.length === 0) {
         Zotero.debug?.(
-          `[llm-for-zotero] Skipping invalid user skill file (missing id or match patterns): ${filePath}`,
+          `[llm-for-zotero] Skipping invalid skill file (missing id or match patterns): ${filePath}`,
         );
         continue;
       }
 
-      // Prefix id to avoid collision with built-in skills
-      skill.id = `user:${skill.id}`;
       skills.push(skill);
     } catch (err) {
       Zotero.debug?.(
-        `[llm-for-zotero] Error loading user skill file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+        `[llm-for-zotero] Error loading skill file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
 
   if (skills.length > 0) {
     Zotero.debug?.(
-      `[llm-for-zotero] Loaded ${skills.length} user skill(s) from ${dir}`,
+      `[llm-for-zotero] Loaded ${skills.length} skill(s) from ${dir}`,
     );
   }
 
   return skills;
+}
+
+// ---------------------------------------------------------------------------
+// Skill file management (used by the skills popup UI)
+// ---------------------------------------------------------------------------
+
+/** List all .md filenames in the user skills directory. */
+export async function listSkillFiles(): Promise<string[]> {
+  const io = getIOUtils();
+  if (!io?.exists || !io?.getChildren) return [];
+
+  const dir = getUserSkillsDir();
+  try {
+    const exists = await io.exists(dir);
+    if (!exists) return [];
+    const entries = await io.getChildren(dir);
+    return entries.filter((entry) => entry.endsWith(".md"));
+  } catch {
+    return [];
+  }
+}
+
+/** Delete a skill file by its full path. */
+export async function deleteSkillFile(filePath: string): Promise<boolean> {
+  const io = getIOUtils();
+  if (!io?.remove) return false;
+
+  try {
+    await io.remove(filePath);
+    return true;
+  } catch (err) {
+    Zotero.debug?.(
+      `[llm-for-zotero] Failed to delete skill file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Create a new skill template file and return its full path.
+ * Auto-generates a unique filename (custom-skill-1.md, custom-skill-2.md, ...).
+ */
+export async function createSkillTemplate(): Promise<string | null> {
+  const io = getIOUtils();
+  if (!io?.exists || !io?.write) return null;
+
+  const dir = getUserSkillsDir();
+  const encoder = new TextEncoder();
+  const template = `---
+id: my-custom-skill
+match: /your regex pattern here/i
+---
+
+Describe when and how the agent should behave when this skill matches.
+`;
+
+  let index = 1;
+  let filePath: string;
+  // Find the next available filename
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    filePath = joinPath(dir, `custom-skill-${index}.md`);
+    try {
+      const exists = await io.exists(filePath);
+      if (!exists) break;
+    } catch {
+      break;
+    }
+    index++;
+    if (index > 999) return null; // safety limit
+  }
+
+  try {
+    await io.write(filePath, encoder.encode(template));
+    return filePath;
+  } catch (err) {
+    Zotero.debug?.(
+      `[llm-for-zotero] Failed to create skill template: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
 }

--- a/src/agent/skills/userSkills.ts
+++ b/src/agent/skills/userSkills.ts
@@ -74,9 +74,31 @@ export function getUserSkillsDir(): string {
 // Initialization — copy missing built-in skills to user folder
 // ---------------------------------------------------------------------------
 
+const SEEDED_PREF_KEY = "extensions.zotero.llmForZotero.seededBuiltinSkills";
+
+/** Read the set of built-in skill filenames that have already been seeded. */
+function getSeededSkills(): Set<string> {
+  try {
+    const raw = Zotero.Prefs?.get(SEEDED_PREF_KEY, true);
+    if (typeof raw === "string" && raw) return new Set(JSON.parse(raw));
+  } catch { /* */ }
+  return new Set();
+}
+
+/** Persist the set of seeded filenames. */
+function setSeededSkills(seeded: Set<string>): void {
+  try {
+    Zotero.Prefs?.set(SEEDED_PREF_KEY, JSON.stringify([...seeded]), true);
+  } catch { /* */ }
+}
+
 /**
- * Ensure the user skills directory exists and contains all built-in skills.
- * Missing built-in files are copied; existing files are never overwritten.
+ * Ensure the user skills directory exists and seed built-in skills.
+ *
+ * Only skills that have **never been seeded** are copied. This means:
+ * - New built-in skills from plugin updates auto-appear.
+ * - If a user deletes a built-in skill, it stays deleted across restarts.
+ *
  * Call this before loadUserSkills().
  */
 export async function initUserSkills(): Promise<void> {
@@ -97,9 +119,11 @@ export async function initUserSkills(): Promise<void> {
     return;
   }
 
+  const seeded = getSeededSkills();
   const encoder = new TextEncoder();
 
   for (const [filename, content] of Object.entries(BUILTIN_SKILL_FILES)) {
+    if (seeded.has(filename)) continue; // already seeded once — respect user deletions
     const filePath = joinPath(dir, filename);
     try {
       const exists = await io.exists(filePath);
@@ -109,12 +133,15 @@ export async function initUserSkills(): Promise<void> {
           `[llm-for-zotero] Copied built-in skill to user folder: ${filename}`,
         );
       }
+      seeded.add(filename);
     } catch (err) {
       Zotero.debug?.(
         `[llm-for-zotero] Failed to copy built-in skill ${filename}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
+
+  setSeededSkills(seeded);
 }
 
 // ---------------------------------------------------------------------------
@@ -191,7 +218,7 @@ export async function loadUserSkills(): Promise<AgentSkill[]> {
 // Skill file management (used by the skills popup UI)
 // ---------------------------------------------------------------------------
 
-/** List all .md filenames in the user skills directory. */
+/** List all .md file paths (full absolute paths) in the user skills directory. */
 export async function listSkillFiles(): Promise<string[]> {
   const io = getIOUtils();
   if (!io?.exists || !io?.getChildren) return [];
@@ -229,9 +256,17 @@ export async function deleteSkillFile(filePath: string): Promise<boolean> {
  */
 export async function createSkillTemplate(): Promise<string | null> {
   const io = getIOUtils();
-  if (!io?.exists || !io?.write) return null;
+  if (!io?.exists || !io?.write || !io?.makeDirectory) return null;
 
   const dir = getUserSkillsDir();
+
+  // Ensure directory exists (user may have deleted it after startup)
+  try {
+    await io.makeDirectory(dir, {
+      createAncestors: true,
+      ignoreExisting: true,
+    });
+  } catch { /* */ }
   const encoder = new TextEncoder();
   const template = `---
 id: my-custom-skill

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -57,8 +57,11 @@ async function onStartup() {
     ztoolkit.log("LLM: Failed to initialize agent subsystem", err);
   }
   try {
-    const { loadUserSkills } = await import("./agent/skills/userSkills");
+    const { initUserSkills, loadUserSkills } = await import(
+      "./agent/skills/userSkills"
+    );
     const { setUserSkills } = await import("./agent/skills");
+    await initUserSkills();
     const userSkills = await loadUserSkills();
     setUserSkills(userSkills);
   } catch (err) {

--- a/src/modules/contextPanel/standaloneWindow.ts
+++ b/src/modules/contextPanel/standaloneWindow.ts
@@ -477,6 +477,11 @@ export function openStandaloneChat(options?: {
     iconSearch.type = "button";
     iconSearch.title = t("Search history");
 
+    const iconSkill = doc.createElementNS(HTML_NS, "button") as HTMLButtonElement;
+    iconSkill.className = "llm-standalone-icon-btn llm-standalone-icon-skill";
+    iconSkill.type = "button";
+    iconSkill.title = t("Skills");
+
     const iconStripSpacer = doc.createElementNS(HTML_NS, "div") as HTMLDivElement;
     iconStripSpacer.style.flex = "1";
 
@@ -495,7 +500,7 @@ export function openStandaloneChat(options?: {
     iconClear.type = "button";
     iconClear.title = t("Clear");
 
-    iconStrip.append(iconSidebarToggle, iconNewChat, iconSearch, iconStripSpacer, iconSettings, iconExport, iconClear);
+    iconStrip.append(iconSidebarToggle, iconNewChat, iconSearch, iconSkill, iconStripSpacer, iconSettings, iconExport, iconClear);
 
     // Export popup — floating menu from sidebar export icon
     const exportPopup = doc.createElementNS(HTML_NS, "div") as HTMLDivElement;
@@ -590,7 +595,52 @@ export function openStandaloneChat(options?: {
     searchPopup.append(searchHeader, searchResults);
     searchOverlay.appendChild(searchPopup);
 
-    root.append(lowerArea, exportPopup, searchOverlay);
+    // -- Skills overlay (popup for managing agent skills) --
+    const skillOverlay = doc.createElementNS(HTML_NS, "div") as HTMLDivElement;
+    skillOverlay.className = "llm-standalone-skill-overlay";
+    skillOverlay.style.display = "none";
+
+    const skillPopup = doc.createElementNS(HTML_NS, "div") as HTMLDivElement;
+    skillPopup.className = "llm-standalone-skill-popup";
+
+    const skillHeader = doc.createElementNS(HTML_NS, "div") as HTMLDivElement;
+    skillHeader.className = "llm-standalone-skill-header";
+
+    const skillTitle = doc.createElementNS(HTML_NS, "span") as HTMLSpanElement;
+    skillTitle.className = "llm-standalone-skill-title";
+    skillTitle.textContent = t("Skills");
+
+    const skillCloseBtn = doc.createElementNS(HTML_NS, "button") as HTMLButtonElement;
+    skillCloseBtn.className = "llm-standalone-search-close";
+    skillCloseBtn.type = "button";
+    skillCloseBtn.textContent = "\u00D7";
+
+    skillHeader.append(skillTitle, skillCloseBtn);
+
+    const skillGrid = doc.createElementNS(HTML_NS, "div") as HTMLDivElement;
+    skillGrid.className = "llm-standalone-skill-grid";
+
+    skillPopup.append(skillHeader, skillGrid);
+    skillOverlay.appendChild(skillPopup);
+
+    // Skills context menu (right-click)
+    const skillCtxMenu = doc.createElementNS(HTML_NS, "div") as HTMLDivElement;
+    skillCtxMenu.className = "llm-standalone-skill-ctx-menu";
+    skillCtxMenu.style.display = "none";
+
+    const skillCtxShowInFs = doc.createElementNS(HTML_NS, "button") as HTMLButtonElement;
+    skillCtxShowInFs.className = "llm-standalone-skill-ctx-item";
+    skillCtxShowInFs.type = "button";
+    skillCtxShowInFs.textContent = t("Show in file system");
+
+    const skillCtxDelete = doc.createElementNS(HTML_NS, "button") as HTMLButtonElement;
+    skillCtxDelete.className = "llm-standalone-skill-ctx-item llm-standalone-skill-ctx-delete";
+    skillCtxDelete.type = "button";
+    skillCtxDelete.textContent = t("Delete");
+
+    skillCtxMenu.append(skillCtxShowInFs, skillCtxDelete);
+
+    root.append(lowerArea, exportPopup, searchOverlay, skillOverlay, skillCtxMenu);
 
     // -- Sidebar state management --
     let userManualSidebarState: "expanded" | "collapsed" | null = null;
@@ -1276,6 +1326,162 @@ export function openStandaloneChat(options?: {
         }
       } catch (err) {
         ztoolkit.log("LLM: standalone search navigate failed", err);
+      }
+    });
+
+    // ----------------------------------------------------------------
+    // Skills popup — open/close/render/interactions
+    // ----------------------------------------------------------------
+    let skillCtxFilePath = ""; // tracks which file the context menu targets
+
+    const renderSkillGrid = async () => {
+      const { listSkillFiles, getUserSkillsDir } = await import(
+        "../../agent/skills/userSkills"
+      );
+      const files = await listSkillFiles();
+      const dir = getUserSkillsDir();
+      skillGrid.textContent = "";
+
+      // "+" add button — first grid item
+      const addBtn = doc.createElementNS(HTML_NS, "button") as HTMLButtonElement;
+      addBtn.className = "llm-standalone-skill-item llm-standalone-skill-add";
+      addBtn.type = "button";
+      const addIcon = doc.createElementNS(HTML_NS, "span") as HTMLSpanElement;
+      addIcon.className = "llm-standalone-skill-add-icon";
+      addIcon.textContent = "+";
+      const addLabel = doc.createElementNS(HTML_NS, "span") as HTMLSpanElement;
+      addLabel.className = "llm-standalone-skill-label";
+      addLabel.textContent = t("New skill");
+      addBtn.append(addIcon, addLabel);
+      addBtn.addEventListener("click", async () => {
+        const { createSkillTemplate } = await import(
+          "../../agent/skills/userSkills"
+        );
+        const filePath = await createSkillTemplate();
+        if (filePath) {
+          const launch = (
+            Zotero as unknown as { launchURL?: (url: string) => void }
+          ).launchURL;
+          if (typeof launch === "function") {
+            launch("file://" + filePath);
+          }
+          void renderSkillGrid();
+        }
+      });
+      skillGrid.appendChild(addBtn);
+
+      // Skill file items
+      for (const fullPath of files) {
+        const filename = fullPath.split("/").pop() || fullPath.split("\\").pop() || fullPath;
+        const item = doc.createElementNS(HTML_NS, "button") as HTMLButtonElement;
+        item.className = "llm-standalone-skill-item";
+        item.type = "button";
+        item.dataset.filePath = fullPath;
+
+        const icon = doc.createElementNS(HTML_NS, "span") as HTMLSpanElement;
+        icon.className = "llm-standalone-skill-doc-icon";
+
+        const label = doc.createElementNS(HTML_NS, "span") as HTMLSpanElement;
+        label.className = "llm-standalone-skill-label";
+        label.textContent = filename;
+
+        item.append(icon, label);
+
+        // Left click — open in system editor
+        item.addEventListener("click", () => {
+          const launch = (
+            Zotero as unknown as { launchURL?: (url: string) => void }
+          ).launchURL;
+          if (typeof launch === "function") {
+            launch("file://" + fullPath);
+          }
+        });
+
+        // Right click — context menu
+        item.addEventListener("contextmenu", (e: Event) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const me = e as MouseEvent;
+          skillCtxFilePath = fullPath;
+          skillCtxMenu.style.display = "flex";
+
+          // Position with viewport bounds checking
+          const menuW = 180;
+          const menuH = 80;
+          let x = me.clientX + 4;
+          let y = me.clientY + 4;
+          if (x + menuW > (doc.documentElement?.clientWidth ?? 9999)) x = me.clientX - menuW;
+          if (y + menuH > (doc.documentElement?.clientHeight ?? 9999)) y = me.clientY - menuH;
+          skillCtxMenu.style.left = `${x}px`;
+          skillCtxMenu.style.top = `${y}px`;
+        });
+
+        skillGrid.appendChild(item);
+      }
+    };
+
+    const openSkillPopup = () => {
+      skillOverlay.style.display = "flex";
+      void renderSkillGrid();
+    };
+
+    const closeSkillPopup = () => {
+      skillOverlay.style.display = "none";
+      skillCtxMenu.style.display = "none";
+    };
+
+    // Skill icon toggle
+    iconSkill.addEventListener("click", () => {
+      if (skillOverlay.style.display !== "none") {
+        closeSkillPopup();
+      } else {
+        openSkillPopup();
+      }
+    });
+
+    skillCloseBtn.addEventListener("click", () => closeSkillPopup());
+
+    skillOverlay.addEventListener("click", (e: Event) => {
+      if (e.target === skillOverlay) closeSkillPopup();
+    });
+
+    // Escape key closes skill popup
+    skillPopup.addEventListener("keydown", (e: Event) => {
+      if ((e as KeyboardEvent).key === "Escape") {
+        e.preventDefault();
+        closeSkillPopup();
+      }
+    });
+
+    // Context menu: Show in file system
+    skillCtxShowInFs.addEventListener("click", async () => {
+      skillCtxMenu.style.display = "none";
+      const { getUserSkillsDir } = await import("../../agent/skills/userSkills");
+      const dir = getUserSkillsDir();
+      try {
+        (
+          Zotero as unknown as { launchFile?: (p: string) => void }
+        ).launchFile?.(dir);
+      } catch { /* */ }
+    });
+
+    // Context menu: Delete
+    skillCtxDelete.addEventListener("click", async () => {
+      skillCtxMenu.style.display = "none";
+      if (!skillCtxFilePath) return;
+      const { deleteSkillFile } = await import("../../agent/skills/userSkills");
+      await deleteSkillFile(skillCtxFilePath);
+      skillCtxFilePath = "";
+      void renderSkillGrid();
+    });
+
+    // Dismiss context menu on click outside
+    doc.addEventListener("mousedown", (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (skillCtxMenu.style.display !== "none") {
+        if (!skillCtxMenu.contains(target)) {
+          skillCtxMenu.style.display = "none";
+        }
       }
     });
 

--- a/src/modules/contextPanel/standaloneWindow.ts
+++ b/src/modules/contextPanel/standaloneWindow.ts
@@ -1334,12 +1334,17 @@ export function openStandaloneChat(options?: {
     // ----------------------------------------------------------------
     let skillCtxFilePath = ""; // tracks which file the context menu targets
 
+    /** Reload the in-memory skill list from disk (call after create/delete). */
+    const reloadRuntimeSkills = async () => {
+      const { loadUserSkills } = await import("../../agent/skills/userSkills");
+      const { setUserSkills } = await import("../../agent/skills");
+      const skills = await loadUserSkills();
+      setUserSkills(skills);
+    };
+
     const renderSkillGrid = async () => {
-      const { listSkillFiles, getUserSkillsDir } = await import(
-        "../../agent/skills/userSkills"
-      );
+      const { listSkillFiles } = await import("../../agent/skills/userSkills");
       const files = await listSkillFiles();
-      const dir = getUserSkillsDir();
       skillGrid.textContent = "";
 
       // "+" add button — first grid item
@@ -1359,12 +1364,12 @@ export function openStandaloneChat(options?: {
         );
         const filePath = await createSkillTemplate();
         if (filePath) {
-          const launch = (
-            Zotero as unknown as { launchURL?: (url: string) => void }
-          ).launchURL;
-          if (typeof launch === "function") {
-            launch("file://" + filePath);
-          }
+          try {
+            (
+              Zotero as unknown as { launchFile?: (p: string) => void }
+            ).launchFile?.(filePath);
+          } catch { /* */ }
+          await reloadRuntimeSkills();
           void renderSkillGrid();
         }
       });
@@ -1389,12 +1394,11 @@ export function openStandaloneChat(options?: {
 
         // Left click — open in system editor
         item.addEventListener("click", () => {
-          const launch = (
-            Zotero as unknown as { launchURL?: (url: string) => void }
-          ).launchURL;
-          if (typeof launch === "function") {
-            launch("file://" + fullPath);
-          }
+          try {
+            (
+              Zotero as unknown as { launchFile?: (p: string) => void }
+            ).launchFile?.(fullPath);
+          } catch { /* */ }
         });
 
         // Right click — context menu
@@ -1445,8 +1449,9 @@ export function openStandaloneChat(options?: {
       if (e.target === skillOverlay) closeSkillPopup();
     });
 
-    // Escape key closes skill popup
-    skillPopup.addEventListener("keydown", (e: Event) => {
+    // Escape key — attached at document level so it works regardless of focus
+    doc.addEventListener("keydown", (e: Event) => {
+      if (skillOverlay.style.display === "none") return;
       if ((e as KeyboardEvent).key === "Escape") {
         e.preventDefault();
         closeSkillPopup();
@@ -1465,13 +1470,14 @@ export function openStandaloneChat(options?: {
       } catch { /* */ }
     });
 
-    // Context menu: Delete
+    // Context menu: Delete (+ reload runtime skills)
     skillCtxDelete.addEventListener("click", async () => {
       skillCtxMenu.style.display = "none";
       if (!skillCtxFilePath) return;
       const { deleteSkillFile } = await import("../../agent/skills/userSkills");
       await deleteSkillFile(skillCtxFilePath);
       skillCtxFilePath = "";
+      await reloadRuntimeSkills();
       void renderSkillGrid();
     });
 


### PR DESCRIPTION
## Summary
- Built-in skills are now copied to the user's data directory on first startup; the agent reads exclusively from there, giving users full ownership
- New sidebar icon in standalone window opens a skills popup (grid of `.md` files)
- Left-click opens skill in system editor, right-click shows "Show in file system" / "Delete", "+" button creates a new template

## Test plan
- [ ] Delete user skills folder, restart Zotero — verify 9 built-in skills are copied
- [ ] Click skill icon in standalone window — popup appears/disappears
- [ ] Left-click a skill item — opens in system default `.md` editor
- [ ] Click "+" — creates `custom-skill-1.md` template and opens it
- [ ] Right-click a skill → "Delete" — file removed, grid updates
- [ ] Right-click → "Show in file system" — Finder/Explorer opens at skills dir
- [ ] Close popup via X button, overlay click, and Escape key
- [ ] Plugin update with new built-in skill — only the new one is copied, existing edits preserved
- [ ] Edit a skill's match pattern, send matching message in agent mode — modified instruction appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)