### PR TITLE
refactor: Simplify and fix the logic for obtaining the Zotero data directory

### DIFF
--- a/src/claudeCode/projectSkills.ts
+++ b/src/claudeCode/projectSkills.ts
@@ -86,20 +86,6 @@ function getNsIFile(): unknown {
   return components?.interfaces?.nsIFile;
 }
 
-function getHomeDir(): string {
-  const env = getProcess()?.env;
-  const home =
-    env?.HOME?.trim() ||
-    env?.USERPROFILE?.trim() ||
-    getPathUtils()?.homeDir?.trim() ||
-    getOS()?.Constants?.Path?.homeDir?.trim() ||
-    getServices()?.dirsvc?.get?.("Home", getNsIFile())?.path?.trim() ||
-    (Zotero as unknown as { Profile?: { dir?: string } }).Profile?.dir?.trim() ||
-    "";
-  if (home) return home;
-  throw new Error("Cannot resolve home directory for Claude runtime root");
-}
-
 export function getClaudeProfileDir(): string {
   const profileDir = (Zotero as unknown as { Profile?: { dir?: string } }).Profile?.dir?.trim();
   if (profileDir) return profileDir;
@@ -121,12 +107,19 @@ export function getClaudeProfileSignature(): string {
 }
 
 export function getClaudeRuntimeRootDir(): string {
-  return joinLocalPath(
-    getHomeDir(),
-    "Zotero",
-    "agent-runtime",
-    getClaudeProfileSignature(),
-  );
+  const zotero = Zotero as unknown as {
+    DataDirectory?: { dir?: string };
+    Profile?: { dir?: string };
+  };
+  const dataDir = zotero.DataDirectory?.dir?.trim();
+  if (dataDir) {
+    return joinLocalPath(dataDir, "agent-runtime", getClaudeProfileSignature());
+  }
+  const profileDir = zotero.Profile?.dir?.trim();
+  if (profileDir) {
+    return joinLocalPath(profileDir, "Zotero", "agent-runtime", getClaudeProfileSignature());
+  }
+  throw new Error("Cannot resolve Zotero data directory for Claude runtime root");
 }
 
 export function getClaudeProjectDir(): string {

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -2335,16 +2335,14 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
   };
 
   const getCurrentClaudeLocalDir = (): string => {
-    const env = getProcess()?.env;
-    const home =
-      env?.HOME?.trim() ||
-      env?.USERPROFILE?.trim() ||
-      getPathUtils()?.homeDir?.trim() ||
-      getOS()?.Constants?.Path?.homeDir?.trim() ||
-      getServices()?.dirsvc?.get?.("Home", getNsIFile())?.path?.trim() ||
-      (Zotero as unknown as { Profile?: { dir?: string } }).Profile?.dir?.trim() ||
-      ".";
-    const runtimeRoot = joinLocalPath(home, "Zotero", "agent-runtime", getClaudeProfileSignature());
+    const zotero = Zotero as unknown as {
+      DataDirectory?: { dir?: string };
+      Profile?: { dir?: string };
+    };
+    const dataDir = zotero.DataDirectory?.dir?.trim();
+    const runtimeRoot = dataDir
+      ? joinLocalPath(dataDir, "agent-runtime", getClaudeProfileSignature())
+      : joinLocalPath((Zotero as unknown as { Profile?: { dir?: string } }).Profile?.dir?.trim() || ".", "Zotero", "agent-runtime", getClaudeProfileSignature());
     const scopesRoot = joinLocalPath(runtimeRoot, "scopes");
     const conversationSystem = getConversationSystemPref();
     if (conversationSystem !== "claude_code") {
@@ -2380,16 +2378,16 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
   const renderClaudeConfigPaths = () => {
     if (!claudeConfigPathsWrap) return;
     claudeConfigPathsWrap.replaceChildren();
-    const env = getProcess()?.env;
-    const home =
-      env?.HOME?.trim() ||
-      env?.USERPROFILE?.trim() ||
-      getPathUtils()?.homeDir?.trim() ||
-      getOS()?.Constants?.Path?.homeDir?.trim() ||
-      getServices()?.dirsvc?.get?.("Home", getNsIFile())?.path?.trim() ||
-      (Zotero as unknown as { Profile?: { dir?: string } }).Profile?.dir?.trim() ||
-      "";
-    const runtimeRoot = joinLocalPath(home || ".", "Zotero", "agent-runtime", getClaudeProfileSignature());
+    const zotero = Zotero as unknown as {
+      DataDirectory?: { dir?: string };
+      Profile?: { dir?: string };
+    };
+    const dataDir = zotero.DataDirectory?.dir?.trim();
+    const profileDir = zotero.Profile?.dir?.trim() || ".";
+    const home = profileDir;
+    const runtimeRoot = dataDir
+      ? joinLocalPath(dataDir, "agent-runtime", getClaudeProfileSignature())
+      : joinLocalPath(profileDir, "Zotero", "agent-runtime", getClaudeProfileSignature());
     const projectClaudeDir = joinLocalPath(runtimeRoot, ".claude");
     const localConversationDir = joinLocalPath(
       runtimeRoot,


### PR DESCRIPTION
Fix the issue where the Claude module hardcodes the Zotero data directory as {home}/Zotero/. 

This is the code before modification:

```ts
return joinLocalPath(
  getHomeDir(),
  "Zotero",
  "agent-runtime",
  getClaudeProfileSignature(),
);
```

This commit only tested on Linux. Further testing and modifications may be necessary.