### PR TITLE
Use configured Codex CLI path in Agent setup actions

### DIFF
--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -118,6 +118,7 @@ import {
   setClaudeBlockStreamingEnabled,
 } from "../claudeCode/prefs";
 import {
+  getCodexBinaryPathPref,
   getCodexReasoningModePref,
   getCodexRuntimeModelPref,
   isCodexZoteroMcpToolsEnabled,
@@ -2070,7 +2071,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
           const result = await runCodexAppServerConnectionTest({
             modelName:
               codexAppServerModelInput?.value || getCodexRuntimeModelPref(),
-            codexPath: "",
+            codexPath: getCodexBinaryPathPref(),
           });
           codexAppServerStatus.textContent =
             `${t("✓ Success — model says: ")}"${result.reply}"`;
@@ -2116,7 +2117,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
         renderCodexMcpStatus(t("Configuring Zotero MCP tools…"));
         try {
           const status = await installOrUpdateCodexZoteroMcpConfig({
-            codexPath: "",
+            codexPath: getCodexBinaryPathPref(),
           });
           setCodexZoteroMcpToolsEnabled(true);
           if (codexAppServerMcpEnableInput) {
@@ -2145,7 +2146,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
 
   if (codexAppServerMcpStatus && isCodexZoteroMcpToolsEnabled()) {
     renderCodexMcpStatus(t("Checking Zotero MCP setup…"));
-    void readCodexNativeMcpSetupStatus({ codexPath: "" })
+    void readCodexNativeMcpSetupStatus({ codexPath: getCodexBinaryPathPref() })
       .then((status) => {
         renderCodexMcpStatus(
           status.connected === true


### PR DESCRIPTION
This fixes a Windows configuration issue where the Agent tab ignored the configured Codex CLI path when testing Codex App Server or configuring Zotero MCP tools.

The plugin already stores the Codex CLI path in `codexAppServerPath` and exposes it through `getCodexBinaryPathPref()`, but the Agent settings page still passed `codexPath: ""` to:

- `runCodexAppServerConnectionTest`
- `installOrUpdateCodexZoteroMcpConfig`
- `readCodexNativeMcpSetupStatus`

On Windows, this can cause `codex binary not found` even when the user has configured a native Codex path such as `C:\nvm4w\nodejs\codex.cmd`.

This PR reuses `getCodexBinaryPathPref()` for those Agent actions. If no path is configured, the getter returns an empty string, preserving the existing auto-detect behavior.

I could not run the full typecheck locally because dependencies were not installed in my source zip checkout, but the change is limited to using an already-exported preference getter.
