### PR TITLE
The problem of pdf lack when sending too much in one batch

### DIFF
--- a/src/modules/contextPanel/pdfPageCapture.ts
+++ b/src/modules/contextPanel/pdfPageCapture.ts
@@ -17,12 +17,46 @@ function unwrapWrappedJsObject<T>(value: T): T {
 }
 
 type RenderablePdfPage = {
-  getViewport: (opts: { scale: number }) => { width: number; height: number };
+  view?: number[];
+  rotate?: number;
+  userUnit?: number;
+  pageInfo?: { view?: number[] };
+  _pageInfo?: { view?: number[] };
+  getViewport: (...args: unknown[]) => unknown;
   render: (opts: {
     canvasContext: CanvasRenderingContext2D;
     viewport: unknown;
   }) => unknown;
+  cleanup?: () => void;
 };
+
+type ViewportLike = {
+  viewBox?: number[];
+  scale?: number;
+  rotation?: number;
+  offsetX?: number;
+  offsetY?: number;
+  transform?: number[];
+  width?: number;
+  height?: number;
+  rawDims?: {
+    pageWidth: number;
+    pageHeight: number;
+    pageX: number;
+    pageY: number;
+  };
+  userUnit?: number;
+  dontFlip?: boolean;
+};
+
+type CloneIntoFn = <T extends object>(
+  value: T,
+  targetScope: unknown,
+  options?: {
+    cloneFunctions?: boolean;
+    wrapReflectors?: boolean;
+  },
+) => T;
 
 function resolveRenderablePdfPage(value: unknown): RenderablePdfPage | null {
   const queue: unknown[] = [value];
@@ -167,26 +201,443 @@ async function waitForRenderedPageCanvas(
   return null;
 }
 
+function getCloneInto(): CloneIntoFn | undefined {
+  const globalWithClone = globalThis as unknown as {
+    cloneInto?: CloneIntoFn;
+    Components?: { utils?: { cloneInto?: CloneIntoFn } };
+  };
+  return globalWithClone.cloneInto || globalWithClone.Components?.utils?.cloneInto;
+}
+
+function canvasToDataUrl(canvas: HTMLCanvasElement | null): string | null {
+  if (!canvas || !canvas.width || !canvas.height) return null;
+  try {
+    return canvas.toDataURL("image/png");
+  } catch {
+    const doc = canvas.ownerDocument || document;
+    const temp = doc?.createElement?.("canvas") as HTMLCanvasElement | null;
+    if (!temp) return null;
+    temp.width = Math.max(1, canvas.width);
+    temp.height = Math.max(1, canvas.height);
+    const ctx = temp.getContext("2d");
+    if (!ctx) {
+      temp.width = 0;
+      temp.height = 0;
+      return null;
+    }
+    ctx.drawImage(canvas, 0, 0);
+    let dataUrl: string | null = null;
+    try {
+      dataUrl = temp.toDataURL("image/png");
+    } catch {
+      dataUrl = null;
+    }
+    temp.width = 0;
+    temp.height = 0;
+    return dataUrl;
+  }
+}
+
+function isCanvasLikelyBlank(canvas: HTMLCanvasElement | null): boolean {
+  if (!canvas || !canvas.width || !canvas.height) return true;
+  try {
+    const doc = canvas.ownerDocument || document;
+    const sample = doc?.createElement?.("canvas") as HTMLCanvasElement | null;
+    if (!sample) return false;
+    sample.width = 128;
+    sample.height = 128;
+    const ctx = sample.getContext("2d", { willReadFrequently: true });
+    if (!ctx) {
+      sample.width = 0;
+      sample.height = 0;
+      return false;
+    }
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, sample.width, sample.height);
+    ctx.drawImage(canvas, 0, 0, sample.width, sample.height);
+    const imageData = ctx.getImageData(0, 0, sample.width, sample.height).data;
+    let nonBlankPixels = 0;
+    for (let index = 0; index < imageData.length; index += 4) {
+      const alpha = imageData[index + 3];
+      const red = imageData[index];
+      const green = imageData[index + 1];
+      const blue = imageData[index + 2];
+      if (alpha > 8 && (red < 250 || green < 250 || blue < 250)) {
+        nonBlankPixels += 1;
+        if (nonBlankPixels > 24) break;
+      }
+    }
+    sample.width = 0;
+    sample.height = 0;
+    return nonBlankPixels <= 24;
+  } catch {
+    return false;
+  }
+}
+
+function isValidViewport(viewport: unknown): viewport is ViewportLike {
+  const width = Number((viewport as ViewportLike | null)?.width);
+  const height = Number((viewport as ViewportLike | null)?.height);
+  return Boolean(
+    viewport &&
+      Number.isFinite(width) &&
+      width > 0 &&
+      Number.isFinite(height) &&
+      height > 0,
+  );
+}
+
+function getSafeViewport(
+  targetLabel: string,
+  pdfPage: RenderablePdfPage,
+  scale: number,
+): {
+  ok: true;
+  viewport: ViewportLike;
+  width: number;
+  height: number;
+  scaleUsed: number;
+  mode: string;
+} | {
+  ok: false;
+} {
+  const safeScale =
+    Number.isFinite(Number(scale)) && Number(scale) > 0 ? Number(scale) : 1.5;
+  const safeRotation =
+    Number.isFinite(Number(pdfPage?.rotate)) ? Number(pdfPage.rotate) : 0;
+
+  const attempts = [
+    {
+      scale: safeScale,
+      run: (target: RenderablePdfPage, nextScale: number) =>
+        target.getViewport({
+          scale: nextScale,
+          rotation: safeRotation,
+          offsetX: 0,
+          offsetY: 0,
+          dontFlip: false,
+        }),
+      suffix: "object",
+    },
+    {
+      scale: safeScale,
+      run: (target: RenderablePdfPage, nextScale: number) =>
+        target.getViewport(nextScale, safeRotation, false),
+      suffix: "legacy",
+    },
+  ];
+
+  if (Math.abs(safeScale - 1.5) > 1e-3) {
+    attempts.push(
+      {
+        scale: 1.5,
+        run: (target: RenderablePdfPage, nextScale: number) =>
+          target.getViewport({
+            scale: nextScale,
+            rotation: safeRotation,
+            offsetX: 0,
+            offsetY: 0,
+            dontFlip: false,
+          }),
+        suffix: "object-fallback",
+      },
+      {
+        scale: 1.5,
+        run: (target: RenderablePdfPage, nextScale: number) =>
+          target.getViewport(nextScale, safeRotation, false),
+        suffix: "legacy-fallback",
+      },
+    );
+  }
+
+  for (const attempt of attempts) {
+    try {
+      const viewport = unwrapWrappedJsObject(
+        attempt.run(pdfPage, attempt.scale),
+      ) as ViewportLike;
+      if (isValidViewport(viewport)) {
+        return {
+          ok: true,
+          viewport,
+          width: Number(viewport.width),
+          height: Number(viewport.height),
+          scaleUsed: attempt.scale,
+          mode: `${targetLabel}.${attempt.suffix}`,
+        };
+      }
+    } catch {
+      // fall through to the next signature
+    }
+  }
+
+  return { ok: false };
+}
+
+function buildManualViewport(
+  pageLike: RenderablePdfPage,
+  scale: number,
+): {
+  ok: true;
+  viewport: ViewportLike;
+  width: number;
+  height: number;
+  scaleUsed: number;
+  mode: string;
+} | {
+  ok: false;
+} {
+  const sourceView = Array.isArray(pageLike?.view)
+    ? pageLike.view
+    : Array.isArray(pageLike?._pageInfo?.view)
+      ? pageLike._pageInfo.view
+      : Array.isArray(pageLike?.pageInfo?.view)
+        ? pageLike.pageInfo.view
+        : null;
+  if (!Array.isArray(sourceView) || sourceView.length !== 4) {
+    return { ok: false };
+  }
+  const viewBox = sourceView.map((value) => Number(value));
+  if (viewBox.some((value) => !Number.isFinite(value))) {
+    return { ok: false };
+  }
+  const safeScale =
+    Number.isFinite(Number(scale)) && Number(scale) > 0 ? Number(scale) : 1.5;
+  const safeRotation =
+    Number.isFinite(Number(pageLike?.rotate)) ? Number(pageLike.rotate) : 0;
+  const safeUserUnit =
+    Number.isFinite(Number(pageLike?.userUnit)) && Number(pageLike.userUnit) > 0
+      ? Number(pageLike.userUnit)
+      : 1;
+  const [x1, y1, x2, y2] = viewBox;
+  const pageWidth = x2 - x1;
+  const pageHeight = y2 - y1;
+  if (
+    !Number.isFinite(pageWidth) ||
+    pageWidth <= 0 ||
+    !Number.isFinite(pageHeight) ||
+    pageHeight <= 0
+  ) {
+    return { ok: false };
+  }
+
+  const normalizedRotation = ((safeRotation % 360) + 360) % 360;
+  let rotateA = 1;
+  let rotateB = 0;
+  let rotateC = 0;
+  let rotateD = -1;
+  switch (normalizedRotation) {
+    case 0:
+      break;
+    case 90:
+      rotateA = 0;
+      rotateB = 1;
+      rotateC = 1;
+      rotateD = 0;
+      break;
+    case 180:
+      rotateA = -1;
+      rotateB = 0;
+      rotateC = 0;
+      rotateD = 1;
+      break;
+    case 270:
+      rotateA = 0;
+      rotateB = -1;
+      rotateC = -1;
+      rotateD = 0;
+      break;
+    default:
+      return { ok: false };
+  }
+
+  const totalScale = safeScale * safeUserUnit;
+  const centerX = (x2 + x1) / 2;
+  const centerY = (y2 + y1) / 2;
+  let width = pageWidth * totalScale;
+  let height = pageHeight * totalScale;
+  let offsetCanvasX: number;
+  let offsetCanvasY: number;
+  if (rotateA === 0) {
+    offsetCanvasX = Math.abs(centerY - y1) * totalScale;
+    offsetCanvasY = Math.abs(centerX - x1) * totalScale;
+    width = pageHeight * totalScale;
+    height = pageWidth * totalScale;
+  } else {
+    offsetCanvasX = Math.abs(centerX - x1) * totalScale;
+    offsetCanvasY = Math.abs(centerY - y1) * totalScale;
+  }
+
+  const viewport: ViewportLike = {
+    viewBox,
+    scale: totalScale,
+    rotation: normalizedRotation,
+    offsetX: 0,
+    offsetY: 0,
+    transform: [
+      rotateA * totalScale,
+      rotateB * totalScale,
+      rotateC * totalScale,
+      rotateD * totalScale,
+      offsetCanvasX - rotateA * totalScale * centerX - rotateC * totalScale * centerY,
+      offsetCanvasY - rotateB * totalScale * centerX - rotateD * totalScale * centerY,
+    ],
+    width,
+    height,
+    rawDims: {
+      pageWidth,
+      pageHeight,
+      pageX: x1,
+      pageY: y1,
+    },
+    userUnit: safeUserUnit,
+    dontFlip: false,
+  };
+
+  return {
+    ok: true,
+    viewport,
+    width,
+    height,
+    scaleUsed: safeScale,
+    mode: "manual.viewbox",
+  };
+}
+
+function scopeViewportForRender(
+  viewport: ViewportLike,
+  canvasDoc: Document,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reader: any,
+): ViewportLike {
+  try {
+    const renderWindow = unwrapWrappedJsObject(
+      canvasDoc.defaultView || reader?._iframeWindow || null,
+    ) as Window | null;
+    const cloneIntoFn = getCloneInto();
+    const payload = {
+      viewBox: Array.isArray(viewport.viewBox) ? [...viewport.viewBox] : viewport.viewBox,
+      scale: viewport.scale,
+      rotation: viewport.rotation,
+      offsetX: viewport.offsetX,
+      offsetY: viewport.offsetY,
+      transform: Array.isArray(viewport.transform)
+        ? [...viewport.transform]
+        : viewport.transform,
+      width: viewport.width,
+      height: viewport.height,
+      rawDims: viewport.rawDims
+        ? {
+            pageWidth: viewport.rawDims.pageWidth,
+            pageHeight: viewport.rawDims.pageHeight,
+            pageX: viewport.rawDims.pageX,
+            pageY: viewport.rawDims.pageY,
+          }
+        : viewport.rawDims,
+      userUnit: viewport.userUnit,
+      dontFlip: viewport.dontFlip,
+    };
+
+    if (renderWindow && typeof cloneIntoFn === "function") {
+      try {
+        return cloneIntoFn(payload, renderWindow, {
+          cloneFunctions: false,
+          wrapReflectors: true,
+        }) as unknown as ViewportLike;
+      } catch {
+        // fall through to manual scoping below
+      }
+    }
+
+    const ScopedObject =
+      renderWindow?.Object || canvasDoc.defaultView?.Object;
+    const ScopedArray = renderWindow?.Array || canvasDoc.defaultView?.Array;
+    if (typeof ScopedObject !== "function" || typeof ScopedArray !== "function") {
+      return viewport;
+    }
+    const scopedViewport = new ScopedObject() as ViewportLike;
+    scopedViewport.viewBox = Array.isArray(payload.viewBox)
+      ? ScopedArray.from(payload.viewBox)
+      : payload.viewBox;
+    scopedViewport.scale = payload.scale;
+    scopedViewport.rotation = payload.rotation;
+    scopedViewport.offsetX = payload.offsetX;
+    scopedViewport.offsetY = payload.offsetY;
+    scopedViewport.transform = Array.isArray(payload.transform)
+      ? ScopedArray.from(payload.transform)
+      : payload.transform;
+    scopedViewport.width = payload.width;
+    scopedViewport.height = payload.height;
+    scopedViewport.rawDims = payload.rawDims
+      ? ({
+          pageWidth: payload.rawDims.pageWidth,
+          pageHeight: payload.rawDims.pageHeight,
+          pageX: payload.rawDims.pageX,
+          pageY: payload.rawDims.pageY,
+        } as ViewportLike["rawDims"])
+      : payload.rawDims;
+    scopedViewport.userUnit = payload.userUnit;
+    scopedViewport.dontFlip = payload.dontFlip;
+    return scopedViewport;
+  } catch {
+    return viewport;
+  }
+}
+
+function resolvePdfViewport(
+  rawPage: unknown,
+  pdfPage: RenderablePdfPage,
+  scale: number,
+): {
+  viewport: ViewportLike;
+  width: number;
+  height: number;
+  scaleUsed: number;
+  mode: string;
+} | null {
+  const candidates: Array<[string, RenderablePdfPage]> = [];
+  const addCandidate = (label: string, value: unknown) => {
+    const candidate = resolveRenderablePdfPage(value);
+    if (!candidate) return;
+    if (candidates.some((entry) => entry[1] === candidate)) return;
+    candidates.push([label, candidate]);
+  };
+
+  addCandidate("resolved", pdfPage);
+  addCandidate("raw", rawPage);
+  if (rawPage && typeof rawPage === "object") {
+    const rec = rawPage as Record<string, unknown>;
+    addCandidate("raw.pdfPage", rec.pdfPage);
+    addCandidate("raw._pdfPage", rec._pdfPage);
+    addCandidate("raw.page", rec.page);
+    addCandidate("raw.pageProxy", rec.pageProxy);
+  }
+
+  for (const [label, candidate] of candidates) {
+    const safeViewport = getSafeViewport(label, candidate, scale);
+    if (safeViewport.ok) {
+      return safeViewport;
+    }
+  }
+
+  const manualViewport = buildManualViewport(pdfPage, scale);
+  return manualViewport.ok ? manualViewport : null;
+}
+
 async function renderPdfPageToDataUrl(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   app: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reader: any,
   pageNumber: number,
+  options: { scale?: number } = {},
 ): Promise<string | null> {
-  const canvasDoc =
-    Zotero.getMainWindow?.()?.document || getReaderDocument(reader);
+  const canvasDoc = getReaderDocument(reader) || Zotero.getMainWindow?.()?.document;
   if (!canvasDoc) return null;
-
-  let pdfPage: (RenderablePdfPage & { cleanup?: () => void }) | null = null;
-  let offscreen: HTMLCanvasElement | null = null;
 
   const pdfDocument = unwrapWrappedJsObject(
     app.pdfDocument as { getPage?: (n: number) => Promise<unknown> },
   );
-  if (
-    typeof (pdfDocument as { getPage?: unknown }).getPage !== "function"
-  ) {
+  if (typeof (pdfDocument as { getPage?: unknown }).getPage !== "function") {
     return null;
   }
 
@@ -194,46 +645,98 @@ async function renderPdfPageToDataUrl(
     const rawPage = await (
       pdfDocument as { getPage: (n: number) => Promise<unknown> }
     ).getPage(pageNumber);
-    pdfPage = resolveRenderablePdfPage(rawPage) as
-      | (RenderablePdfPage & { cleanup?: () => void })
-      | null;
+    const pdfPage = resolveRenderablePdfPage(rawPage);
     if (!pdfPage) return null;
 
-    const viewport = pdfPage.getViewport({ scale: 1.8 });
-    offscreen = canvasDoc.createElement("canvas") as HTMLCanvasElement;
-    offscreen.width = Math.max(1, Math.ceil(viewport.width));
-    offscreen.height = Math.max(1, Math.ceil(viewport.height));
-    const context = offscreen.getContext("2d") as CanvasRenderingContext2D | null;
-    if (!context) return null;
+    const requestedScale = Number(options.scale);
+    const preferredScale =
+      Number.isFinite(requestedScale) && requestedScale > 0
+        ? requestedScale
+        : 1.8;
+    const viewportResult = resolvePdfViewport(rawPage, pdfPage, preferredScale);
+    if (!viewportResult) return null;
 
-    const renderTask = pdfPage.render({ canvasContext: context, viewport });
-    if (
-      renderTask &&
-      typeof renderTask === "object" &&
-      "promise" in renderTask &&
-      (renderTask as { promise: Promise<unknown> }).promise
-    ) {
-      await (renderTask as { promise: Promise<unknown> }).promise;
-    } else if (
-      renderTask &&
-      typeof (renderTask as { then?: unknown }).then === "function"
-    ) {
-      await renderTask;
-    }
+    const offscreen = canvasDoc.createElement("canvas") as HTMLCanvasElement;
+    offscreen.width = Math.max(1, Math.ceil(viewportResult.width));
+    offscreen.height = Math.max(1, Math.ceil(viewportResult.height));
+    offscreen.style.width = `${offscreen.width}px`;
+    offscreen.style.height = `${offscreen.height}px`;
 
-    return offscreen.toDataURL("image/png");
-  } catch {
-    return null;
-  } finally {
+    let dataUrl: string | null = null;
     try {
-      pdfPage?.cleanup?.();
-    } catch {
-      // PDF.js cleanup is best-effort only.
-    }
-    if (offscreen) {
+      const context = offscreen.getContext("2d") as CanvasRenderingContext2D | null;
+      if (!context) return null;
+
+      const rawContext = unwrapWrappedJsObject(context) as CanvasRenderingContext2D;
+      const rawViewport = unwrapWrappedJsObject(viewportResult.viewport) as ViewportLike;
+      const renderViewport =
+        viewportResult.mode === "manual.viewbox"
+          ? scopeViewportForRender(rawViewport, canvasDoc, reader)
+          : rawViewport;
+
+      let renderParams: { canvasContext: CanvasRenderingContext2D; viewport: unknown } | unknown = {
+        canvasContext: rawContext,
+        viewport: renderViewport,
+      };
+      const renderWindow = unwrapWrappedJsObject(
+        canvasDoc.defaultView || reader?._iframeWindow || null,
+      ) as Window | null;
+      const cloneIntoFn = getCloneInto();
+      if (renderWindow && typeof cloneIntoFn === "function") {
+        try {
+          renderParams = cloneIntoFn(
+            {
+              canvasContext: rawContext,
+              viewport: renderViewport,
+            },
+            renderWindow,
+            {
+              cloneFunctions: false,
+              wrapReflectors: true,
+            },
+          );
+        } catch {
+          // fall back to plain params
+        }
+      }
+
+      const renderTask = pdfPage.render(
+        renderParams as {
+          canvasContext: CanvasRenderingContext2D;
+          viewport: unknown;
+        },
+      );
+      if (
+        renderTask &&
+        typeof renderTask === "object" &&
+        "promise" in renderTask &&
+        (renderTask as { promise: Promise<unknown> }).promise
+      ) {
+        await (renderTask as { promise: Promise<unknown> }).promise;
+      } else if (
+        renderTask &&
+        (typeof renderTask === "object" || typeof renderTask === "function") &&
+        "then" in renderTask &&
+        typeof (renderTask as { then?: unknown }).then === "function"
+      ) {
+        await renderTask;
+      }
+
+      const exported = canvasToDataUrl(offscreen);
+      dataUrl = exported && !isCanvasLikelyBlank(offscreen) ? exported : null;
+    } finally {
+      try {
+        pdfPage.cleanup?.();
+      } catch {
+        // cleanup is best-effort
+      }
       offscreen.width = 0;
       offscreen.height = 0;
     }
+
+    return dataUrl;
+  } catch {
+    return null;
   }
 }
 
@@ -324,10 +827,69 @@ export function parsePageRanges(input: string, maxPage: number): number[] {
 }
 
 /**
+ * Navigates the reader to a specific page index (0-based).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function navigateReaderToPage(reader: any, pageIndex: number): Promise<boolean> {
+  if (typeof reader?.navigate !== "function") return false;
+  const idx = Math.max(0, Math.floor(pageIndex));
+  try {
+    await reader.navigate({ pageIndex: idx, pageLabel: `${idx + 1}` });
+    return true;
+  } catch {
+    try {
+      await reader.navigate({ pageIndex: idx });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Captures the rendered canvas for a given page (1-indexed) as a PNG data URL.
+ * Prefers off-screen PDF.js rendering and only falls back to the visible reader
+ * canvas after off-screen attempts fail.
+ */
+async function capturePageByNavigation(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reader: any,
+  pageNumber: number,
+  options: { scale?: number } = {},
+): Promise<string | null> {
+  const primary = await renderPdfPageToDataUrl(app, reader, pageNumber, {
+    scale: options.scale,
+  });
+  if (primary) return primary;
+
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  const retryScale =
+    Number.isFinite(options.scale) && (options.scale as number) > 1
+      ? Math.max(1, Math.min(options.scale as number, (options.scale as number) - 0.35))
+      : 1;
+  const retry = await renderPdfPageToDataUrl(app, reader, pageNumber, {
+    scale: retryScale,
+  });
+  if (retry) return retry;
+
+  await navigateReaderToPage(reader, pageNumber - 1);
+  const rendered = await waitForRenderedPageCanvas(app, reader, pageNumber, 3000);
+  if (rendered && rendered.width > 0 && rendered.height > 0) {
+    const visibleUrl = canvasToDataUrl(rendered);
+    if (visibleUrl && !isCanvasLikelyBlank(rendered)) {
+      return visibleUrl;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Captures specific PDF pages (1-indexed) as high-quality PNG data URLs.
- * Each requested page is rendered into a fresh off-screen canvas via PDF.js.
- * The multi-page flow intentionally avoids depending on reader navigation or
- * visible reader-canvas capture.
+ * Navigates the reader to each page and captures the rendered canvas,
+ * then restores the original page position.
  */
 export async function capturePdfPages(
   pageNumbers: number[],
@@ -341,25 +903,43 @@ export async function capturePdfPages(
   const app = getPdfViewerApplication(reader);
   if (!app?.pdfDocument) return [];
 
+  // Remember original page so we can restore it after
+  const originalPageNumber = Number(
+    app?.pdfViewer?.currentPageNumber ||
+      app?.pdfViewer?.currentPageLabel ||
+      app?.page ||
+      1,
+  );
+
   const results: string[] = [];
-  const failedPages: number[] = [];
   const total = pageNumbers.length;
-  for (let idx = 0; idx < total; idx++) {
-    opts?.onProgress?.(idx + 1, total);
-    const pageNumber = pageNumbers[idx];
-    const dataUrl = await renderPdfPageToDataUrl(app, reader, pageNumber);
-    if (dataUrl) {
-      results.push(dataUrl);
-    } else {
-      failedPages.push(pageNumber);
+  const renderScale = Number.isFinite(total)
+    ? total >= 16
+      ? 1
+      : total >= 10
+        ? 1.1
+        : total >= 6
+          ? 1.25
+          : 1.8
+    : 1.8;
+  try {
+    for (let idx = 0; idx < total; idx++) {
+      opts?.onProgress?.(idx + 1, total);
+      const dataUrl = await capturePageByNavigation(
+        app,
+        reader,
+        pageNumbers[idx],
+        { scale: renderScale },
+      );
+      if (dataUrl) {
+        results.push(dataUrl);
+      }
+      await new Promise((resolve) => setTimeout(resolve, total >= 10 ? 25 : 0));
     }
+  } finally {
+    // Restore original page position
+    const restoreIndex = Math.max(0, Math.floor(originalPageNumber) - 1);
+    await navigateReaderToPage(reader, restoreIndex);
   }
-
-  if (failedPages.length) {
-    throw new Error(
-      `Failed to render PDF pages off-screen: ${failedPages.join(", ")}`,
-    );
-  }
-
   return results;
 }

--- a/src/modules/contextPanel/pdfPageCapture.ts
+++ b/src/modules/contextPanel/pdfPageCapture.ts
@@ -175,8 +175,11 @@ async function renderPdfPageToDataUrl(
   pageNumber: number,
 ): Promise<string | null> {
   const canvasDoc =
-    getReaderDocument(reader) || Zotero.getMainWindow?.()?.document;
+    Zotero.getMainWindow?.()?.document || getReaderDocument(reader);
   if (!canvasDoc) return null;
+
+  let pdfPage: (RenderablePdfPage & { cleanup?: () => void }) | null = null;
+  let offscreen: HTMLCanvasElement | null = null;
 
   const pdfDocument = unwrapWrappedJsObject(
     app.pdfDocument as { getPage?: (n: number) => Promise<unknown> },
@@ -191,11 +194,13 @@ async function renderPdfPageToDataUrl(
     const rawPage = await (
       pdfDocument as { getPage: (n: number) => Promise<unknown> }
     ).getPage(pageNumber);
-    const pdfPage = resolveRenderablePdfPage(rawPage);
+    pdfPage = resolveRenderablePdfPage(rawPage) as
+      | (RenderablePdfPage & { cleanup?: () => void })
+      | null;
     if (!pdfPage) return null;
 
     const viewport = pdfPage.getViewport({ scale: 1.8 });
-    const offscreen = canvasDoc.createElement("canvas") as HTMLCanvasElement;
+    offscreen = canvasDoc.createElement("canvas") as HTMLCanvasElement;
     offscreen.width = Math.max(1, Math.ceil(viewport.width));
     offscreen.height = Math.max(1, Math.ceil(viewport.height));
     const context = offscreen.getContext("2d") as CanvasRenderingContext2D | null;
@@ -219,6 +224,16 @@ async function renderPdfPageToDataUrl(
     return offscreen.toDataURL("image/png");
   } catch {
     return null;
+  } finally {
+    try {
+      pdfPage?.cleanup?.();
+    } catch {
+      // PDF.js cleanup is best-effort only.
+    }
+    if (offscreen) {
+      offscreen.width = 0;
+      offscreen.height = 0;
+    }
   }
 }
 
@@ -309,75 +324,10 @@ export function parsePageRanges(input: string, maxPage: number): number[] {
 }
 
 /**
- * Navigates the reader to a specific page index (0-based).
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function navigateReaderToPage(reader: any, pageIndex: number): Promise<boolean> {
-  if (typeof reader?.navigate !== "function") return false;
-  const idx = Math.max(0, Math.floor(pageIndex));
-  try {
-    await reader.navigate({ pageIndex: idx, pageLabel: `${idx + 1}` });
-    return true;
-  } catch {
-    try {
-      await reader.navigate({ pageIndex: idx });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-}
-
-/**
- * Captures the rendered canvas for a given page (1-indexed) as a PNG data URL.
- * Navigates the reader to that page, then renders it off-screen via PDF.js.
- * Falls back to the reader canvas only if the off-screen render fails.
- */
-async function capturePageByNavigation(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  app: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  reader: any,
-  pageNumber: number,
-): Promise<string | null> {
-  const pageIndex = pageNumber - 1;
-  await navigateReaderToPage(reader, pageIndex);
-
-  const offscreenDataUrl = await renderPdfPageToDataUrl(app, reader, pageNumber);
-  if (offscreenDataUrl) return offscreenDataUrl;
-
-  // Fallback: grab the rendered canvas if off-screen rendering failed.
-  const rendered = await waitForRenderedPageCanvas(app, reader, pageNumber);
-  if (rendered && rendered.width > 0 && rendered.height > 0) {
-    try {
-      return rendered.toDataURL("image/png");
-    } catch {
-      // Canvas may be tainted — try copying to a temp canvas
-      const doc = rendered.ownerDocument || getReaderDocument(reader);
-      if (doc) {
-        const temp = doc.createElement("canvas") as HTMLCanvasElement;
-        temp.width = rendered.width;
-        temp.height = rendered.height;
-        const ctx = temp.getContext("2d") as CanvasRenderingContext2D | null;
-        if (ctx) {
-          ctx.drawImage(rendered, 0, 0);
-          try {
-            return temp.toDataURL("image/png");
-          } catch {
-            // fall through to PDF.js fallback
-          }
-        }
-      }
-    }
-  }
-
-  return null;
-}
-
-/**
  * Captures specific PDF pages (1-indexed) as high-quality PNG data URLs.
- * Navigates the reader to each page and captures the rendered canvas,
- * then restores the original page position.
+ * Each requested page is rendered into a fresh off-screen canvas via PDF.js.
+ * The multi-page flow intentionally avoids depending on reader navigation or
+ * visible reader-canvas capture.
  */
 export async function capturePdfPages(
   pageNumbers: number[],
@@ -391,28 +341,25 @@ export async function capturePdfPages(
   const app = getPdfViewerApplication(reader);
   if (!app?.pdfDocument) return [];
 
-  // Remember original page so we can restore it after
-  const originalPageNumber = Number(
-    app?.pdfViewer?.currentPageNumber ||
-      app?.pdfViewer?.currentPageLabel ||
-      app?.page ||
-      1,
-  );
-
   const results: string[] = [];
+  const failedPages: number[] = [];
   const total = pageNumbers.length;
-  try {
-    for (let idx = 0; idx < total; idx++) {
-      opts?.onProgress?.(idx + 1, total);
-      const dataUrl = await capturePageByNavigation(app, reader, pageNumbers[idx]);
-      if (dataUrl) {
-        results.push(dataUrl);
-      }
+  for (let idx = 0; idx < total; idx++) {
+    opts?.onProgress?.(idx + 1, total);
+    const pageNumber = pageNumbers[idx];
+    const dataUrl = await renderPdfPageToDataUrl(app, reader, pageNumber);
+    if (dataUrl) {
+      results.push(dataUrl);
+    } else {
+      failedPages.push(pageNumber);
     }
-  } finally {
-    // Restore original page position
-    const restoreIndex = Math.max(0, Math.floor(originalPageNumber) - 1);
-    await navigateReaderToPage(reader, restoreIndex);
   }
+
+  if (failedPages.length) {
+    throw new Error(
+      `Failed to render PDF pages off-screen: ${failedPages.join(", ")}`,
+    );
+  }
+
   return results;
 }

--- a/src/modules/contextPanel/pdfPageCapture.ts
+++ b/src/modules/contextPanel/pdfPageCapture.ts
@@ -167,6 +167,61 @@ async function waitForRenderedPageCanvas(
   return null;
 }
 
+async function renderPdfPageToDataUrl(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reader: any,
+  pageNumber: number,
+): Promise<string | null> {
+  const canvasDoc =
+    getReaderDocument(reader) || Zotero.getMainWindow?.()?.document;
+  if (!canvasDoc) return null;
+
+  const pdfDocument = unwrapWrappedJsObject(
+    app.pdfDocument as { getPage?: (n: number) => Promise<unknown> },
+  );
+  if (
+    typeof (pdfDocument as { getPage?: unknown }).getPage !== "function"
+  ) {
+    return null;
+  }
+
+  try {
+    const rawPage = await (
+      pdfDocument as { getPage: (n: number) => Promise<unknown> }
+    ).getPage(pageNumber);
+    const pdfPage = resolveRenderablePdfPage(rawPage);
+    if (!pdfPage) return null;
+
+    const viewport = pdfPage.getViewport({ scale: 1.8 });
+    const offscreen = canvasDoc.createElement("canvas") as HTMLCanvasElement;
+    offscreen.width = Math.max(1, Math.ceil(viewport.width));
+    offscreen.height = Math.max(1, Math.ceil(viewport.height));
+    const context = offscreen.getContext("2d") as CanvasRenderingContext2D | null;
+    if (!context) return null;
+
+    const renderTask = pdfPage.render({ canvasContext: context, viewport });
+    if (
+      renderTask &&
+      typeof renderTask === "object" &&
+      "promise" in renderTask &&
+      (renderTask as { promise: Promise<unknown> }).promise
+    ) {
+      await (renderTask as { promise: Promise<unknown> }).promise;
+    } else if (
+      renderTask &&
+      typeof (renderTask as { then?: unknown }).then === "function"
+    ) {
+      await renderTask;
+    }
+
+    return offscreen.toDataURL("image/png");
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Captures the currently visible PDF page in the active Zotero reader as a
  * PNG data URL, or returns null if no PDF is open / rendering fails.
@@ -204,47 +259,7 @@ export async function captureCurrentPdfPage(): Promise<string | null> {
   }
 
   // Fallback: render the page off-screen via the PDF.js API.
-  const canvasDoc =
-    getReaderDocument(reader) || Zotero.getMainWindow?.()?.document;
-  if (!canvasDoc) return null;
-
-  const pdfDocument = unwrapWrappedJsObject(
-    app.pdfDocument as { getPage?: (n: number) => Promise<unknown> },
-  );
-  if (
-    typeof (pdfDocument as { getPage?: unknown }).getPage !== "function"
-  ) {
-    return null;
-  }
-  const rawPage = await (
-    pdfDocument as { getPage: (n: number) => Promise<unknown> }
-  ).getPage(pageNumber);
-  const pdfPage = resolveRenderablePdfPage(rawPage);
-  if (!pdfPage) return null;
-
-  const viewport = pdfPage.getViewport({ scale: 1.8 });
-  const offscreen = canvasDoc.createElement("canvas") as HTMLCanvasElement;
-  offscreen.width = Math.max(1, Math.ceil(viewport.width));
-  offscreen.height = Math.max(1, Math.ceil(viewport.height));
-  const context = offscreen.getContext("2d") as CanvasRenderingContext2D | null;
-  if (!context) return null;
-
-  const renderTask = pdfPage.render({ canvasContext: context, viewport });
-  if (
-    renderTask &&
-    typeof renderTask === "object" &&
-    "promise" in renderTask &&
-    (renderTask as { promise: Promise<unknown> }).promise
-  ) {
-    await (renderTask as { promise: Promise<unknown> }).promise;
-  } else if (
-    renderTask &&
-    typeof (renderTask as { then?: unknown }).then === "function"
-  ) {
-    await renderTask;
-  }
-
-  return offscreen.toDataURL("image/png");
+  return renderPdfPageToDataUrl(app, reader, pageNumber);
 }
 
 /**
@@ -315,8 +330,8 @@ async function navigateReaderToPage(reader: any, pageIndex: number): Promise<boo
 
 /**
  * Captures the rendered canvas for a given page (1-indexed) as a PNG data URL.
- * Navigates the reader to that page, waits for the canvas to render, and grabs it.
- * Falls back to off-screen PDF.js rendering if the canvas grab fails.
+ * Navigates the reader to that page, then renders it off-screen via PDF.js.
+ * Falls back to the reader canvas only if the off-screen render fails.
  */
 async function capturePageByNavigation(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -328,7 +343,10 @@ async function capturePageByNavigation(
   const pageIndex = pageNumber - 1;
   await navigateReaderToPage(reader, pageIndex);
 
-  // Fast path: grab the rendered canvas
+  const offscreenDataUrl = await renderPdfPageToDataUrl(app, reader, pageNumber);
+  if (offscreenDataUrl) return offscreenDataUrl;
+
+  // Fallback: grab the rendered canvas if off-screen rendering failed.
   const rendered = await waitForRenderedPageCanvas(app, reader, pageNumber);
   if (rendered && rendered.width > 0 && rendered.height > 0) {
     try {
@@ -353,50 +371,7 @@ async function capturePageByNavigation(
     }
   }
 
-  // Fallback: render off-screen via PDF.js API
-  const canvasDoc =
-    getReaderDocument(reader) || Zotero.getMainWindow?.()?.document;
-  if (!canvasDoc) return null;
-
-  const pdfDocument = unwrapWrappedJsObject(
-    app.pdfDocument as { getPage?: (n: number) => Promise<unknown> },
-  );
-  if (typeof (pdfDocument as { getPage?: unknown }).getPage !== "function") {
-    return null;
-  }
-  try {
-    const rawPage = await (
-      pdfDocument as { getPage: (n: number) => Promise<unknown> }
-    ).getPage(pageNumber);
-    const pdfPage = resolveRenderablePdfPage(rawPage);
-    if (!pdfPage) return null;
-
-    const viewport = pdfPage.getViewport({ scale: 1.8 });
-    const offscreen = canvasDoc.createElement("canvas") as HTMLCanvasElement;
-    offscreen.width = Math.max(1, Math.ceil(viewport.width));
-    offscreen.height = Math.max(1, Math.ceil(viewport.height));
-    const context = offscreen.getContext("2d") as CanvasRenderingContext2D | null;
-    if (!context) return null;
-
-    const renderTask = pdfPage.render({ canvasContext: context, viewport });
-    if (
-      renderTask &&
-      typeof renderTask === "object" &&
-      "promise" in renderTask &&
-      (renderTask as { promise: Promise<unknown> }).promise
-    ) {
-      await (renderTask as { promise: Promise<unknown> }).promise;
-    } else if (
-      renderTask &&
-      typeof (renderTask as { then?: unknown }).then === "function"
-    ) {
-      await renderTask;
-    }
-
-    return offscreen.toDataURL("image/png");
-  } catch {
-    return null;
-  }
+  return null;
 }
 
 /**

--- a/src/modules/contextPanel/setupHandlers/controllers/composeCaptureController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/composeCaptureController.ts
@@ -567,18 +567,21 @@ export function attachComposeCaptureController(
               nextImages.length - 1,
             );
             deps.updateImagePreviewPreservingScroll();
-            setStatus(`${dataUrls.length} pages captured`, "ready");
+            if (dataUrls.length < pageNumbers.length) {
+              setStatus(
+                `${dataUrls.length}/${pageNumbers.length} pages captured`,
+                "warning",
+              );
+            } else {
+              setStatus(`${dataUrls.length} pages captured`, "ready");
+            }
           } else {
             setStatus(t("PDF page capture failed"), "error");
             deps.updateImagePreviewPreservingScroll();
           }
         } catch (error) {
           deps.log("PDF multiple pages capture error:", error);
-          const errorMessage =
-            error instanceof Error && error.message
-              ? error.message
-              : t("PDF page capture failed");
-          setStatus(errorMessage, "error");
+          setStatus(t("PDF page capture failed"), "error");
           deps.updateImagePreviewPreservingScroll();
         }
       },

--- a/src/modules/contextPanel/setupHandlers/controllers/composeCaptureController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/composeCaptureController.ts
@@ -574,7 +574,11 @@ export function attachComposeCaptureController(
           }
         } catch (error) {
           deps.log("PDF multiple pages capture error:", error);
-          setStatus(t("PDF page capture failed"), "error");
+          const errorMessage =
+            error instanceof Error && error.message
+              ? error.message
+              : t("PDF page capture failed");
+          setStatus(errorMessage, "error");
           deps.updateImagePreviewPreservingScroll();
         }
       },

--- a/src/modules/contextPanel/setupHandlers/controllers/sendFlowController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/sendFlowController.ts
@@ -329,19 +329,26 @@ export function createSendFlowController(deps: SendFlowControllerDeps): {
         primarySelectedText,
         selectedFiles.length > 0 ||
           selectedPaperContexts.length > 0 ||
-          selectedCollectionContexts.length > 0,
+          selectedCollectionContexts.length > 0 ||
+          hasImageInputs,
       );
-      if (!promptText) return;
+      let resolvedPromptText = promptText;
+      if (!resolvedPromptText && hasImageInputs) {
+        resolvedPromptText = "Please analyze the attached images.";
+      }
+      if (!resolvedPromptText) return;
 
-      const resolvedPromptText =
+      if (
         !text &&
         !primarySelectedText &&
         selectedPaperContexts.length + selectedCollectionContexts.length > 0 &&
-        !selectedFiles.length
-          ? selectedPaperContexts.length
-            ? "Please analyze selected papers."
-            : "Please analyze selected collection."
-          : promptText;
+        !selectedFiles.length &&
+        !hasImageInputs
+      ) {
+        resolvedPromptText = selectedPaperContexts.length
+          ? "Please analyze selected papers."
+          : "Please analyze selected collection.";
+      }
 
       const composedQuestionBase = primarySelectedText
         ? deps.buildQuestionWithSelectedTextContexts(

--- a/src/modules/contextPanel/setupHandlers/controllers/sendFlowController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/sendFlowController.ts
@@ -299,6 +299,8 @@ export function createSendFlowController(deps: SendFlowControllerDeps): {
         pdfPageImageDataUrls,
         pdfUploadSystemMessages,
       } = pdfInputs;
+      const hasImageInputs =
+        selectedImages.length > 0 || pdfPageImageDataUrls.length > 0;
       if (isWebChat && selectedCollectionContexts.length) {
         deps.setStatusMessage?.(
           "Web chat does not support Zotero collection context. Remove the collection and try again.",
@@ -316,7 +318,8 @@ export function createSendFlowController(deps: SendFlowControllerDeps): {
         !primarySelectedText &&
         !selectedPaperContexts.length &&
         !selectedCollectionContexts.length &&
-        !selectedFiles.length
+        !selectedFiles.length &&
+        !hasImageInputs
       ) {
         return;
       }


### PR DESCRIPTION
## small note

 When I made a typecheck in my local check, I noticed that some type errors appear. My current understanding is that this is likely due to my local PR working tree/environment being incomplete or not fully aligned with the project’s expected setup.

For example, some global declarations seem to be missing or not loaded correctly, which then causes errors around globals such as ztoolkit and __env__ in other files. These errors do not seem to be caused by the file I changed.

So I would treat my local repo-wide typecheck result as not fully reliable, and I’d suggest double-checking it in the normal project environment or CI. Thank you!


## Summary

This change makes multi-page PDF capture prefer off-screen PDF.js rendering for each requested page, and only fall back to the reader canvas if off-screen rendering fails.

## Why

When many PDF pages are selected at once, capturing from the visible reader canvas can sometimes produce blank white page images. Rendering each page directly through PDF.js is more reliable for the multi-page flow.

## Changes

- extract shared off-screen PDF.js page rendering into a helper
- reuse that helper in current-page capture fallback
- make multi-page page-by-page capture prefer off-screen rendering first
- keep reader canvas capture only as a fallback path

## Validation

- no editor errors reported for `src/modules/contextPanel/pdfPageCapture.ts`
- repository-wide typecheck currently reports unrelated existing errors in other modules, but not in this changed file