### PR TITLE
Add Gemini WebChat target

### DIFF
--- a/src/webchat/pipeline.ts
+++ b/src/webchat/pipeline.ts
@@ -91,7 +91,7 @@ export type WebChatSendOptions = {
   images?: string[];
   /** ChatGPT mode: "instant", "thinking_standard", or "thinking_extended". */
   chatgptMode?: string;
-  /** Which webchat target to use: "chatgpt" | "deepseek". */
+  /** Which webchat target to use: "chatgpt" | "deepseek" | "gemini". */
   target?: string;
   signal?: AbortSignal;
   onAnswerSnapshot: (text: string, snapshot: WebChatAnswerSnapshot) => void;

--- a/src/webchat/relayServer.ts
+++ b/src/webchat/relayServer.ts
@@ -112,7 +112,7 @@ export interface RelayState {
     pdf_filename: string | null;
     images: string[] | null;
     chatgpt_mode: string | null;
-    /** Which webchat site to target: "chatgpt" | "deepseek". */
+    /** Which webchat site to target: "chatgpt" | "deepseek" | "gemini". */
     target: string | null;
     force_new_chat: boolean;
     seq: number;
@@ -155,7 +155,7 @@ export interface RelayState {
   reported_mode: string | null;
   /** [webchat] Set by cancel button — polled separately so it works during active pipeline. */
   stopRequested: boolean;
-  /** [webchat] Active target site: "chatgpt" | "deepseek". Set by the plugin when submitting queries. */
+  /** [webchat] Active target site. Set by the plugin when submitting queries. */
   active_target: string | null;
 }
 

--- a/src/webchat/types.ts
+++ b/src/webchat/types.ts
@@ -35,6 +35,13 @@ export const WEBCHAT_TARGETS = [
     modelName: "chat.deepseek.com",
     displayName: "deepseek",
   },
+  {
+    id: "gemini",
+    label: "Gemini",
+    defaultHost: "http://127.0.0.1:23119/llm-for-zotero/webchat",
+    modelName: "gemini.google.com",
+    displayName: "gemini",
+  },
 ] as const satisfies readonly WebChatTargetEntry[];
 
 export type WebChatTarget = (typeof WEBCHAT_TARGETS)[number]["id"];
@@ -43,7 +50,7 @@ export function getWebChatTarget(id: string): WebChatTargetEntry | undefined {
   return WEBCHAT_TARGETS.find((t) => t.id === id);
 }
 
-/** Resolve a WebChatTarget from a model name like "chatgpt.com" or "chat.deepseek.com". */
+/** Resolve a WebChatTarget from a model/site name like "chatgpt.com". */
 export function getWebChatTargetByModelName(
   modelName: string,
 ): WebChatTargetEntry | undefined {

--- a/test/webchatTypes.test.ts
+++ b/test/webchatTypes.test.ts
@@ -14,8 +14,13 @@ describe("webchat target types", function () {
       getWebChatTargetByModelName("chat.deepseek.com")?.modelName,
       "chat.deepseek.com",
     );
+    assert.equal(
+      getWebChatTargetByModelName("gemini.google.com")?.modelName,
+      "gemini.google.com",
+    );
 
     assert.equal(getWebChatTargetDisplayName("chatgpt.com"), "chatgpt");
     assert.equal(getWebChatTargetDisplayName("chat.deepseek.com"), "deepseek");
+    assert.equal(getWebChatTargetDisplayName("gemini.google.com"), "gemini");
   });
 });


### PR DESCRIPTION
Add gemini.google.com to the WebChat target registry so the relay can send target: "gemini" to compatible browser extensions.