### PR TITLE
fix(reasoning): enable xhigh for gpt-5.5

### DIFF
--- a/src/utils/reasoningProfiles.ts
+++ b/src/utils/reasoningProfiles.ts
@@ -601,7 +601,7 @@ const PROFILE_RULES: Record<
         profile: OPENAI_GPT5_CODEX_PROFILE,
       },
       {
-        match: /^gpt-5\.4(?:\b|[.-])/,
+        match: /^gpt-5\.(?:4|5)(?:\b|[.-])/,
         profile: OPENAI_GPT5_XHIGH_PROFILE,
       },
       {

--- a/test/reasoningProfiles.test.ts
+++ b/test/reasoningProfiles.test.ts
@@ -28,6 +28,18 @@ describe("reasoningProfiles", function () {
       });
     });
 
+    it("supports xhigh reasoning for gpt-5.5", function () {
+      const options = getRuntimeReasoningOptionsForModel("openai", "gpt-5.5");
+      assert.deepEqual(
+        options.map((option) => option.level),
+        ["default", "low", "medium", "high", "xhigh"],
+      );
+
+      const profile = getOpenAIReasoningProfileForModel("gpt-5.5");
+      assert.equal(profile.defaultLevel, "default");
+      assert.equal(profile.levelToEffort.xhigh, "xhigh");
+    });
+
     it("limits gpt-5.4-pro to medium/high/xhigh reasoning", function () {
       const options = getRuntimeReasoningOptionsForModel(
         "openai",


### PR DESCRIPTION
## Summary

- Enable the OpenAI reasoning profile with `xhigh` for `gpt-5.5`.
- Add a regression test that asserts `gpt-5.5` exposes `xhigh`.

## Root Cause

`gpt-5.5` fell through to the generic GPT-5 profile, which only exposed `default`, `low`, `medium`, and `high`.

## Test Plan

- Verified the regression assertion fails before the profile change and passes after it.
- Ran `tsc --noEmit --skipLibCheck src/utils/reasoningProfiles.ts`.
- Built the plugin successfully in a clean temporary copy with Node v24.13.1.
- Verified the generated XPI with `unzip -t`.
