### PR TITLE
[codex] add per-model image input capability override

### DIFF
--- a/src/agent/model/messageBuilder.ts
+++ b/src/agent/model/messageBuilder.ts
@@ -47,6 +47,7 @@ function resolveRequestProviderCapabilities(
     protocol: request.providerProtocol,
     authMode: request.authMode,
     apiBase: request.apiBase,
+    imageInputCapability: request.imageInputCapability,
   });
 }
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,4 +1,5 @@
 import type { ModelProviderAuthMode } from "../utils/modelProviders";
+import type { ImageInputCapability } from "../providers";
 import type { ProviderProtocol } from "../utils/providerProtocol";
 import type {
   AdvancedModelParams,
@@ -41,6 +42,7 @@ export type AgentRequest = {
   apiBase?: string;
   apiKey?: string;
   providerProtocol?: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
   reasoning?: LLMReasoningConfig;
   advanced?: AdvancedModelParams;
 };

--- a/src/modules/contextPanel/agentMode/agentEngine.ts
+++ b/src/modules/contextPanel/agentMode/agentEngine.ts
@@ -93,6 +93,7 @@ import type { ResolvedContextSource } from "../types";
 import type { UsageStats } from "../../../shared/llm";
 import type { ReasoningConfig as LLMReasoningConfig } from "../../../utils/llmClient";
 import type { ChatMessage } from "../../../utils/llmClient";
+import type { ImageInputCapability } from "../../../providers";
 import type { StoredChatMessage } from "../../../utils/chatStore";
 import type { Message } from "../types";
 import { isClaudeBlockStreamingEnabled } from "../../../claudeCode/prefs";
@@ -350,6 +351,7 @@ type EffectiveRequestConfigShape = {
     | "anthropic_messages"
     | "gemini_native"
     | "web_sync";
+  imageInputCapability?: ImageInputCapability;
   modelEntryId?: string;
   modelProviderLabel?: string;
   reasoning: LLMReasoningConfig | undefined;
@@ -510,6 +512,7 @@ export type AgentEngineDeps = {
       | "anthropic_messages"
       | "gemini_native"
       | "web_sync";
+    imageInputCapability?: ImageInputCapability;
     modelEntryId?: string;
     modelProviderLabel?: string;
     reasoning?: LLMReasoningConfig;
@@ -611,6 +614,7 @@ export async function sendAgentTurn(
       | "anthropic_messages"
       | "gemini_native"
       | "web_sync";
+    imageInputCapability?: ImageInputCapability;
     modelEntryId?: string;
     modelProviderLabel?: string;
     reasoning?: LLMReasoningConfig;
@@ -641,6 +645,7 @@ export async function sendAgentTurn(
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,
@@ -769,6 +774,7 @@ export async function sendAgentTurn(
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,
@@ -1424,6 +1430,7 @@ export async function retryAgentTurn(
     | "gemini_native"
     | "web_sync"
     | undefined,
+  imageInputCapability: ImageInputCapability | undefined,
   modelEntryId: string | undefined,
   modelProviderLabel: string | undefined,
   reasoning: LLMReasoningConfig | undefined,
@@ -1457,6 +1464,7 @@ export async function retryAgentTurn(
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,

--- a/src/modules/contextPanel/chat.ts
+++ b/src/modules/contextPanel/chat.ts
@@ -225,7 +225,11 @@ import {
   ensureNoteTextCached,
   ensurePDFTextCached,
 } from "./pdfContext";
-import { isTextOnlyModel, resolveProviderCapabilities } from "../../providers";
+import {
+  isTextOnlyModel,
+  resolveProviderCapabilities,
+  type ImageInputCapability,
+} from "../../providers";
 import {
   getActiveContextAttachmentFromTabs,
   resolveContextSourceItem,
@@ -2997,6 +3001,7 @@ export type EffectiveRequestConfig = {
     | "copilot_auth"
     | "webchat";
   providerProtocol?: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
   modelEntryId?: string;
   modelProviderLabel?: string;
   reasoning: LLMReasoningConfig | undefined;
@@ -3058,6 +3063,7 @@ function resolveEffectiveRequestConfig(params: {
     | "copilot_auth"
     | "webchat";
   providerProtocol?: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
   modelEntryId?: string;
   modelProviderLabel?: string;
   reasoning?: LLMReasoningConfig;
@@ -3108,6 +3114,7 @@ function resolveEffectiveRequestConfig(params: {
           apiKey: params.apiKey ?? "",
           authMode: params.authMode || "api_key",
           providerProtocol: params.providerProtocol || "anthropic_messages",
+          imageInputCapability: params.imageInputCapability,
           providerLabel: params.modelProviderLabel,
           advanced: params.advanced,
         }
@@ -3153,6 +3160,10 @@ function resolveEffectiveRequestConfig(params: {
     params.providerProtocol ||
     explicitEntry?.providerProtocol ||
     fallbackEntry?.providerProtocol;
+  const imageInputCapability =
+    params.imageInputCapability ||
+    explicitEntry?.imageInputCapability ||
+    fallbackEntry?.imageInputCapability;
   const reasoning =
     params.reasoning ||
     getSelectedReasoningForItem(
@@ -3169,6 +3180,7 @@ function resolveEffectiveRequestConfig(params: {
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId:
       params.modelEntryId || explicitEntry?.entryId || fallbackEntry?.entryId,
     modelProviderLabel:
@@ -3178,6 +3190,25 @@ function resolveEffectiveRequestConfig(params: {
     reasoning,
     advanced,
   };
+}
+
+function requestConfigSupportsImageInput(
+  config: Pick<
+    EffectiveRequestConfig,
+    | "model"
+    | "providerProtocol"
+    | "authMode"
+    | "apiBase"
+    | "imageInputCapability"
+  >,
+): boolean {
+  return resolveProviderCapabilities({
+    model: config.model,
+    protocol: config.providerProtocol,
+    authMode: config.authMode,
+    apiBase: config.apiBase,
+    imageInputCapability: config.imageInputCapability,
+  }).images;
 }
 
 function resolveCodexNativeConversationScope(params: {
@@ -5264,6 +5295,7 @@ async function resolveRetryModelInputs(params: {
     protocol: params.effectiveRequestConfig.providerProtocol,
     authMode: params.effectiveRequestConfig.authMode,
     apiBase: params.effectiveRequestConfig.apiBase,
+    imageInputCapability: params.effectiveRequestConfig.imageInputCapability,
   }).pdf;
   if (
     params.effectiveRequestConfig.providerProtocol !== "web_sync" &&
@@ -5619,6 +5651,7 @@ export async function editLatestUserMessageAndRetry(
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,
@@ -5637,6 +5670,7 @@ export async function editLatestUserMessageAndRetry(
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,
@@ -5860,6 +5894,7 @@ export async function editLatestUserMessageAndRetry(
       apiKey,
       authMode,
       providerProtocol,
+      imageInputCapability,
       modelEntryId,
       modelProviderLabel,
       reasoning,
@@ -5875,6 +5910,7 @@ export async function editLatestUserMessageAndRetry(
       apiKey,
       authMode,
       providerProtocol,
+      imageInputCapability,
       modelEntryId,
       modelProviderLabel,
       reasoning,
@@ -5899,6 +5935,7 @@ export async function retryLatestAssistantResponse(
     | "copilot_auth"
     | "webchat",
   providerProtocol?: ProviderProtocol,
+  imageInputCapability?: ImageInputCapability,
   modelEntryId?: string,
   modelProviderLabel?: string,
   reasoning?: LLMReasoningConfig,
@@ -5942,6 +5979,7 @@ export async function retryLatestAssistantResponse(
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,
@@ -6222,7 +6260,7 @@ export async function retryLatestAssistantResponse(
     }
 
     // Text-only models reject image_url content, so drop all images.
-    const allImages = isTextOnlyModel(effectiveRequestConfig.model || "")
+    const allImages = !requestConfigSupportsImageInput(effectiveRequestConfig)
       ? []
       : [...(retryScreenshotImages || []), ...(contextPlan.mineruImages || [])];
     const requestParams = {
@@ -6237,6 +6275,7 @@ export async function retryLatestAssistantResponse(
       apiKey: effectiveRequestConfig.apiKey,
       authMode: effectiveRequestConfig.authMode,
       providerProtocol: effectiveRequestConfig.providerProtocol,
+      imageInputCapability: effectiveRequestConfig.imageInputCapability,
       reasoning: effectiveRequestConfig.reasoning,
       temperature: effectiveRequestConfig.advanced?.temperature,
       maxTokens: effectiveRequestConfig.advanced?.maxTokens,
@@ -6598,6 +6637,7 @@ export async function editUserTurnAndRetry(opts: {
     | "copilot_auth"
     | "webchat";
   providerProtocol?: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
   modelEntryId?: string;
   modelProviderLabel?: string;
   reasoning?: LLMReasoningConfig;
@@ -6628,6 +6668,7 @@ export async function editUserTurnAndRetry(opts: {
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,
@@ -6663,6 +6704,7 @@ export async function editUserTurnAndRetry(opts: {
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,
@@ -6874,6 +6916,7 @@ export async function editUserTurnAndRetry(opts: {
       retryRequestConfig.apiKey,
       retryRequestConfig.authMode,
       retryRequestConfig.providerProtocol,
+      retryRequestConfig.imageInputCapability,
       retryRequestConfig.modelEntryId,
       retryRequestConfig.modelProviderLabel,
       retryRequestConfig.reasoning,
@@ -6889,6 +6932,7 @@ export async function editUserTurnAndRetry(opts: {
       retryRequestConfig.apiKey,
       retryRequestConfig.authMode,
       retryRequestConfig.providerProtocol,
+      retryRequestConfig.imageInputCapability,
       retryRequestConfig.modelEntryId,
       retryRequestConfig.modelProviderLabel,
       retryRequestConfig.reasoning,
@@ -7243,6 +7287,7 @@ async function buildAgentRuntimeRequest(
     apiKey: params.effectiveRequestConfig.apiKey,
     authMode: params.effectiveRequestConfig.authMode,
     providerProtocol: params.effectiveRequestConfig.providerProtocol,
+    imageInputCapability: params.effectiveRequestConfig.imageInputCapability,
     reasoning: params.effectiveRequestConfig.reasoning,
     claudeEffortLevel:
       typeof params.effectiveRequestConfig.reasoning?.level === "string"
@@ -7445,6 +7490,7 @@ async function retryLatestAgentResponse(
     | "copilot_auth"
     | "webchat",
   providerProtocol?: ProviderProtocol,
+  imageInputCapability?: ImageInputCapability,
   modelEntryId?: string,
   modelProviderLabel?: string,
   reasoning?: LLMReasoningConfig,
@@ -7466,6 +7512,7 @@ async function retryLatestAgentResponse(
     apiKey,
     authMode,
     providerProtocol,
+    imageInputCapability,
     modelEntryId,
     modelProviderLabel,
     reasoning,
@@ -7491,6 +7538,7 @@ async function sendAgentQuestion(opts: {
     | "copilot_auth"
     | "webchat";
   providerProtocol?: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
   modelEntryId?: string;
   modelProviderLabel?: string;
   reasoning?: LLMReasoningConfig;
@@ -7597,6 +7645,7 @@ export async function sendQuestion(
       apiKey,
       authMode: opts.authMode,
       providerProtocol: opts.providerProtocol,
+      imageInputCapability: opts.imageInputCapability,
       modelEntryId: opts.modelEntryId,
       modelProviderLabel: opts.modelProviderLabel,
       reasoning,
@@ -7731,6 +7780,7 @@ export async function sendQuestion(
     apiKey,
     authMode: opts.authMode,
     providerProtocol: opts.providerProtocol,
+    imageInputCapability: opts.imageInputCapability,
     modelEntryId: opts.modelEntryId,
     modelProviderLabel: opts.modelProviderLabel,
     reasoning,
@@ -8344,7 +8394,9 @@ export async function sendQuestion(
     }
 
     // Text-only models reject image_url content, so drop all images.
-    const allSendImages = isTextOnlyModel(effectiveRequestConfig.model || "")
+    const allSendImages = !requestConfigSupportsImageInput(
+      effectiveRequestConfig,
+    )
       ? []
       : [...(images || []), ...(contextPlan.mineruImages || [])];
     const requestParams = {
@@ -8359,6 +8411,7 @@ export async function sendQuestion(
       apiKey: effectiveRequestConfig.apiKey,
       authMode: effectiveRequestConfig.authMode,
       providerProtocol: effectiveRequestConfig.providerProtocol,
+      imageInputCapability: effectiveRequestConfig.imageInputCapability,
       reasoning: effectiveRequestConfig.reasoning,
       temperature: effectiveRequestConfig.advanced?.temperature,
       maxTokens: effectiveRequestConfig.advanced?.maxTokens,

--- a/src/modules/contextPanel/setupHandlers.ts
+++ b/src/modules/contextPanel/setupHandlers.ts
@@ -2574,6 +2574,7 @@ export function setupHandlers(
       selectedProfile?.providerProtocol,
       selectedProfile?.authMode,
       selectedProfile?.apiBase,
+      selectedProfile?.imageInputCapability,
     );
   };
 
@@ -4447,6 +4448,7 @@ export function setupHandlers(
             entry.providerProtocol,
             entry.authMode,
             entry.apiBase,
+            entry.imageInputCapability,
           );
           const shouldDowngrade = newPdfSupport !== "native";
           if (shouldDowngrade) {
@@ -4630,6 +4632,7 @@ export function setupHandlers(
             entry.apiKey,
             entry.authMode,
             entry.providerProtocol,
+            entry.imageInputCapability,
             entry.entryId,
             entry.providerLabel,
             retryReasoning,
@@ -5668,6 +5671,7 @@ export function setupHandlers(
         profile?.providerProtocol,
         profile?.authMode,
         profile?.apiBase,
+        profile?.imageInputCapability,
       );
     },
     isScreenshotUnsupportedModel,
@@ -6084,8 +6088,20 @@ export function setupHandlers(
     markWebChatPdfUploadedForCurrentConversation,
     resolvePdfPaperAttachments: pdfPaperResolver.resolvePdfPaperAttachments,
     renderPdfPagesAsImages: pdfPaperResolver.renderPdfPagesAsImages,
-    getModelPdfSupport: (modelName, protocol, authMode, apiBase) =>
-      getModelPdfSupport(modelName, protocol, authMode, apiBase),
+    getModelPdfSupport: (
+      modelName,
+      protocol,
+      authMode,
+      apiBase,
+      imageInputCapability,
+    ) =>
+      getModelPdfSupport(
+        modelName,
+        protocol,
+        authMode,
+        apiBase,
+        imageInputCapability,
+      ),
     uploadPdfForProvider: pdfPaperResolver.uploadPdfForProvider,
     resolvePdfBytes: pdfPaperResolver.resolvePdfBytes,
     getSelectedFiles: (itemId) => selectedFileAttachmentCache.get(itemId) || [],

--- a/src/modules/contextPanel/setupHandlers.ts
+++ b/src/modules/contextPanel/setupHandlers.ts
@@ -5,6 +5,7 @@ import { getAllSkills } from "../../agent/skills";
 import type { AgentSkill } from "../../agent/skills/skillLoader";
 import type { RuntimeModelEntry } from "../../utils/modelProviders";
 import type { ConversationSystem } from "../../shared/types";
+import { resolveProviderCapabilities } from "../../providers";
 import {
   getLastUsedModelEntryId,
   getModelEntryById,
@@ -3896,7 +3897,7 @@ export function setupHandlers(
     const ownerDoc = body.ownerDocument;
     if (!ownerDoc) return;
     const { currentModel } = getSelectedModelInfo();
-    const screenshotUnsupported = isScreenshotUnsupportedModel(currentModel);
+    const screenshotUnsupported = !selectedModelSupportsImageInput(currentModel);
     const screenshotDisabledHint = getScreenshotDisabledHint(currentModel);
     let selectedImages = selectedImageCache.get(item.id) || [];
     if (screenshotUnsupported && selectedImages.length) {
@@ -4299,6 +4300,20 @@ export function setupHandlers(
       currentModelDisplay,
       currentModelHint,
     };
+  };
+
+  const selectedModelSupportsImageInput = (fallbackModelName?: string) => {
+    const { selectedEntry, currentModel } = getSelectedModelInfo();
+    if (!selectedEntry) {
+      return !isScreenshotUnsupportedModel(fallbackModelName || currentModel);
+    }
+    return resolveProviderCapabilities({
+      model: selectedEntry.model,
+      protocol: selectedEntry.providerProtocol,
+      authMode: selectedEntry.authMode,
+      apiBase: selectedEntry.apiBase,
+      imageInputCapability: selectedEntry.imageInputCapability,
+    }).images;
   };
 
   updateModelButton = () => {
@@ -6383,6 +6398,8 @@ export function setupHandlers(
       const selectedImages = (
         selectedImageCache.get(currentItem.id) || []
       ).slice(0, MAX_SELECTED_IMAGES);
+      const supportsImageInput =
+        selectedModelSupportsImageInput(activeModelName);
       const pdfInputs = await resolvePdfModeModelInputs({
         deps: {
           setInputDisabled: (disabled) => {
@@ -6406,11 +6423,9 @@ export function setupHandlers(
         },
         paperContexts: pdfModePapers,
         selectedBaseFiles: baseSelectedFiles,
-        selectedImageCountForBudget: isScreenshotUnsupportedModel(
-          activeModelName,
-        )
-          ? 0
-          : selectedImages.length,
+        selectedImageCountForBudget: supportsImageInput
+          ? selectedImages.length
+          : 0,
         profile: selectedProfile,
         currentModelName: activeModelName,
         isWebChat: isWebChatMode(),
@@ -6423,9 +6438,7 @@ export function setupHandlers(
         pdfUploadSystemMessages,
       } = pdfInputs;
       const images = [
-        ...(isScreenshotUnsupportedModel(activeModelName)
-          ? []
-          : selectedImages),
+        ...(supportsImageInput ? selectedImages : []),
         ...pdfPageImageDataUrls,
       ].slice(0, MAX_SELECTED_IMAGES);
       const selectedReasoning = getSelectedReasoning();

--- a/src/modules/contextPanel/setupHandlers/controllers/modelReasoningController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/modelReasoningController.ts
@@ -1,12 +1,10 @@
-import type {
-  ReasoningOption,
-  ReasoningProviderKind,
-} from "../../types";
+import type { ReasoningOption, ReasoningProviderKind } from "../../types";
 import type { ReasoningLevel as LLMReasoningLevel } from "../../../../utils/llmClient";
 
 import {
   isTextOnlyModel,
   resolveProviderCapabilities,
+  type ImageInputCapability,
   type PdfSupport,
 } from "../../../../providers";
 
@@ -21,12 +19,14 @@ export function getModelPdfSupport(
   providerProtocol?: string,
   authMode?: string,
   apiBase?: string,
+  imageInputCapability?: ImageInputCapability,
 ): ModelPdfSupport {
   return resolveProviderCapabilities({
     model: modelName,
     protocol: providerProtocol,
     authMode,
     apiBase,
+    imageInputCapability,
   }).pdf;
 }
 

--- a/src/modules/contextPanel/setupHandlers/controllers/pdfPaperModelInputController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/pdfPaperModelInputController.ts
@@ -1,4 +1,4 @@
-import type { PdfSupport } from "../../../../providers";
+import type { ImageInputCapability, PdfSupport } from "../../../../providers";
 import type { ProviderProtocol } from "../../../../utils/providerProtocol";
 import type { ChatAttachment, PaperContextRef } from "../../types";
 import { FULL_PDF_UNSUPPORTED_MESSAGE } from "../../pdfSupportMessages";
@@ -16,6 +16,7 @@ export type PdfPaperModelInputProfile = {
     | "copilot_auth"
     | "webchat";
   providerProtocol?: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
 } | null;
 
 export type PdfPaperModelInputDeps = {
@@ -28,6 +29,7 @@ export type PdfPaperModelInputDeps = {
     providerProtocol?: string,
     authMode?: string,
     apiBase?: string,
+    imageInputCapability?: ImageInputCapability,
   ) => PdfSupport;
   resolvePdfPaperAttachments: (
     paperContexts: PaperContextRef[],
@@ -118,6 +120,7 @@ export async function resolvePdfModeModelInputs(params: {
     profile?.providerProtocol,
     profile?.authMode,
     profile?.apiBase,
+    profile?.imageInputCapability,
   );
   let displayPdfPaperAttachments: ChatAttachment[] = [];
   let modelPdfPaperAttachments: ChatAttachment[] = [];

--- a/src/modules/contextPanel/setupHandlers/controllers/sendFlowController.ts
+++ b/src/modules/contextPanel/setupHandlers/controllers/sendFlowController.ts
@@ -1,6 +1,10 @@
 import { MAX_SELECTED_IMAGES } from "../../constants";
 import type { ProviderProtocol } from "../../../../utils/providerProtocol";
-import type { PdfSupport } from "../../../../providers";
+import {
+  resolveProviderCapabilities,
+  type ImageInputCapability,
+  type PdfSupport,
+} from "../../../../providers";
 import type {
   AdvancedModelParams,
   ChatAttachment,
@@ -41,7 +45,23 @@ type SelectedProfile = {
     | "copilot_auth"
     | "webchat";
   providerProtocol?: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
 };
+
+function selectedProfileSupportsImageInput(
+  profile: SelectedProfile | null | undefined,
+  fallbackModelName: string,
+  isScreenshotUnsupportedModel: (modelName: string) => boolean,
+): boolean {
+  if (!profile) return !isScreenshotUnsupportedModel(fallbackModelName);
+  return resolveProviderCapabilities({
+    model: profile.model,
+    protocol: profile.providerProtocol,
+    authMode: profile.authMode,
+    apiBase: profile.apiBase,
+    imageInputCapability: profile.imageInputCapability,
+  }).images;
+}
 
 type LatestEditablePair = {
   conversationKey: number;
@@ -87,6 +107,7 @@ type SendFlowControllerDeps = {
     providerProtocol?: string,
     authMode?: string,
     apiBase?: string,
+    imageInputCapability?: ImageInputCapability,
   ) => PdfSupport;
   uploadPdfForProvider: (params: {
     apiBase: string;
@@ -280,11 +301,14 @@ export function createSendFlowController(deps: SendFlowControllerDeps): {
       const selectedImages = deps
         .getSelectedImages(item.id)
         .slice(0, MAX_SELECTED_IMAGES);
-      const selectedImageCountForBudget = deps.isScreenshotUnsupportedModel(
+      const earlySupportsImageInput = selectedProfileSupportsImageInput(
+        earlyProfile,
         earlyModelName,
-      )
-        ? 0
-        : selectedImages.length;
+        deps.isScreenshotUnsupportedModel,
+      );
+      const selectedImageCountForBudget = earlySupportsImageInput
+        ? selectedImages.length
+        : 0;
       const pdfInputs = await resolvePdfModeModelInputs({
         deps: {
           setInputDisabled: (disabled) => {
@@ -443,10 +467,13 @@ export function createSendFlowController(deps: SendFlowControllerDeps): {
         deps.getCurrentModelName() ||
         ""
       ).trim();
+      const activeSupportsImageInput = selectedProfileSupportsImageInput(
+        selectedProfile,
+        activeModelName,
+        deps.isScreenshotUnsupportedModel,
+      );
       const images = [
-        ...(deps.isScreenshotUnsupportedModel(activeModelName)
-          ? []
-          : selectedImages),
+        ...(activeSupportsImageInput ? selectedImages : []),
         ...pdfPageImageDataUrls,
       ];
       const selectedReasoning = deps.getSelectedReasoning();
@@ -507,6 +534,7 @@ export function createSendFlowController(deps: SendFlowControllerDeps): {
           apiKey: selectedProfile?.apiKey,
           authMode: selectedProfile?.authMode,
           providerProtocol: selectedProfile?.providerProtocol,
+          imageInputCapability: selectedProfile?.imageInputCapability,
           modelEntryId: selectedProfile?.entryId,
           modelProviderLabel: selectedProfile?.providerLabel,
           reasoning: selectedReasoning,
@@ -608,6 +636,7 @@ export function createSendFlowController(deps: SendFlowControllerDeps): {
         apiKey: selectedProfile?.apiKey,
         authMode: selectedProfile?.authMode,
         providerProtocol: selectedProfile?.providerProtocol,
+        imageInputCapability: selectedProfile?.imageInputCapability,
         modelEntryId: selectedProfile?.entryId,
         modelProviderLabel: selectedProfile?.providerLabel,
         reasoning: selectedReasoning,

--- a/src/modules/contextPanel/types.ts
+++ b/src/modules/contextPanel/types.ts
@@ -375,6 +375,7 @@ export type ZoteroTabsState = {
 // ── Send flow options ─────────────────────────────────────────────────────
 
 import type { ReasoningConfig as LLMReasoningConfig } from "../../utils/llmClient";
+import type { ImageInputCapability } from "../../providers";
 
 export type SendQuestionOptions = {
   body: Element;
@@ -393,6 +394,7 @@ export type SendQuestionOptions = {
     | "copilot_auth"
     | "webchat";
   providerProtocol?: import("../../utils/providerProtocol").ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
   modelEntryId?: string;
   modelProviderLabel?: string;
   reasoning?: LLMReasoningConfig;
@@ -461,6 +463,7 @@ export type EditRetryOptions = {
     | "copilot_auth"
     | "webchat";
   providerProtocol?: import("../../utils/providerProtocol").ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
   modelEntryId?: string;
   modelProviderLabel?: string;
   reasoning?: LLMReasoningConfig;

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -1483,6 +1483,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
                     }
                   : undefined,
                 m.protocol,
+                existing?.imageInputCapability,
               );
             });
             persistGroups(groups);
@@ -1725,6 +1726,35 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
           "optional",
         );
 
+        const imageCapabilityWrap = el(
+          doc,
+          "div",
+          "display: flex; flex-direction: column; gap: 3px;",
+        );
+        const imageCapabilityLabel = el(
+          doc,
+          "label",
+          "font-size: 10.5px; font-weight: 600; color: var(--fill-primary, inherit);",
+          t("Image input"),
+        );
+        const imageCapabilitySelect = el(
+          doc,
+          "select",
+          PROTOCOL_SELECT_SM_STYLE,
+        ) as HTMLSelectElement;
+        for (const option of [
+          { value: "", label: "auto" },
+          { value: "text_only", label: t("Text only") },
+          { value: "vision", label: t("Supports images") },
+        ]) {
+          const opt = el(doc, "option") as HTMLOptionElement;
+          opt.value = option.value;
+          opt.textContent = option.label;
+          imageCapabilitySelect.appendChild(opt);
+        }
+        imageCapabilitySelect.value = modelEntry.imageInputCapability || "";
+        imageCapabilityWrap.append(imageCapabilityLabel, imageCapabilitySelect);
+
         // ── Per-model protocol override ──
         const protocolFieldWrap = el(
           doc,
@@ -1766,6 +1796,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
           tempField.wrap,
           maxTokField.wrap,
           inputCapField.wrap,
+          imageCapabilityWrap,
           protocolFieldWrap,
         );
         advRow.append(
@@ -1794,12 +1825,18 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
           )
             ? protocolFieldSelect.value
             : undefined;
+          modelEntry.imageInputCapability =
+            imageCapabilitySelect.value === "text_only" ||
+            imageCapabilitySelect.value === "vision"
+              ? imageCapabilitySelect.value
+              : undefined;
           tempField.input.value = `${modelEntry.temperature}`;
           maxTokField.input.value = `${modelEntry.maxTokens}`;
           inputCapField.input.value =
             modelEntry.inputTokenCap !== undefined
               ? `${modelEntry.inputTokenCap}`
               : "";
+          imageCapabilitySelect.value = modelEntry.imageInputCapability || "";
           persistGroups(groups);
         };
         for (const f of [tempField, maxTokField, inputCapField]) {
@@ -1807,6 +1844,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
           f.input.addEventListener("blur", commitAdvanced);
         }
         protocolFieldSelect.addEventListener("change", commitAdvanced);
+        imageCapabilitySelect.addEventListener("change", commitAdvanced);
 
         const syncAdvAvailability = () => {
           const hasModel = Boolean(modelEntry.model.trim());
@@ -1815,6 +1853,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
           for (const f of [tempField, maxTokField, inputCapField])
             f.input.disabled = !hasModel;
           protocolFieldSelect.disabled = !hasModel;
+          imageCapabilitySelect.disabled = !hasModel;
         };
         syncAdvAvailability();
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,5 +4,6 @@ export type {
   ProviderParams,
   ProviderTier,
   PdfSupport,
+  ImageInputCapability,
 } from "./types";
 export { isTextOnlyModel } from "./modelChecks";

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,5 +1,9 @@
 import { isTextOnlyModel } from "./modelChecks";
-import type { ProviderCapabilities, ProviderParams } from "./types";
+import type {
+  ImageInputCapability,
+  ProviderCapabilities,
+  ProviderParams,
+} from "./types";
 import * as native from "./tiers/native";
 import * as serverUpload from "./tiers/serverUpload";
 import * as copilot from "./tiers/copilot";
@@ -13,6 +17,11 @@ import { resolvePromptCacheCapability } from "../contextCache/manager";
 // against a proxy that doesn't expose it).
 const TIERS = [copilot, codex, serverUpload, native, thirdParty] as const;
 
+function normalizeImageInputCapability(value: unknown): ImageInputCapability {
+  if (value === "text_only" || value === "vision") return value;
+  return "auto";
+}
+
 /**
  * Resolve the full provider capability set for the given request
  * parameters.  This is the single entry point that replaces the
@@ -22,7 +31,14 @@ const TIERS = [copilot, codex, serverUpload, native, thirdParty] as const;
 export function resolveProviderCapabilities(
   params: ProviderParams,
 ): ProviderCapabilities {
-  const textOnly = isTextOnlyModel(params.model);
+  const imageInputCapability = normalizeImageInputCapability(
+    params.imageInputCapability,
+  );
+  const imageForcedTextOnly = imageInputCapability === "text_only";
+  const imageForcedVision = imageInputCapability === "vision";
+  const textOnly =
+    imageForcedTextOnly ||
+    (!imageForcedVision && isTextOnlyModel(params.model));
 
   const matched = TIERS.find((tier) => tier.matches(params));
   const base = matched?.capabilities ?? thirdParty.capabilities;
@@ -30,7 +46,8 @@ export function resolveProviderCapabilities(
   return {
     ...base,
     promptCache: resolvePromptCacheCapability(params),
-    multimodal: !textOnly,
+    multimodal: imageForcedVision || !textOnly,
+    ...(imageForcedVision ? { images: true } : {}),
     ...(textOnly ? { pdf: "none" as const, images: false } : {}),
   };
 }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -7,6 +7,8 @@ export type ProviderTier =
   | "copilot"
   | "codex";
 
+export type ImageInputCapability = "auto" | "text_only" | "vision";
+
 export type ProviderCapabilities = {
   tier: ProviderTier;
   label: string;
@@ -21,6 +23,7 @@ export type ProviderParams = {
   protocol?: string;
   authMode?: string;
   apiBase?: string;
+  imageInputCapability?: ImageInputCapability;
 };
 
 export type ProviderPromptCacheKind =

--- a/src/utils/llmClient.ts
+++ b/src/utils/llmClient.ts
@@ -70,6 +70,10 @@ import {
   type ModelProviderAuthMode,
 } from "./modelProviders";
 import {
+  resolveProviderCapabilities,
+  type ImageInputCapability,
+} from "../providers";
+import {
   detectProviderPreset,
   getProviderPreset,
   isGrokApiBase,
@@ -94,7 +98,6 @@ import {
   getModelInputTokenLimit,
   type InputCapResult,
 } from "./modelInputCap";
-import { isTextOnlyModel } from "../providers/modelChecks";
 import {
   extractContextCacheUsage,
   type ContextCachePlan,
@@ -142,6 +145,8 @@ export type ChatParams = {
   systemMessages?: string[];
   /** Override provider protocol for this request */
   providerProtocol?: ProviderProtocol;
+  /** Per-model image input override from provider settings. */
+  imageInputCapability?: ImageInputCapability;
   /** Provider-side prompt/context cache plan resolved by the context planner. */
   contextCache?: ContextCachePlan;
 };
@@ -230,6 +235,7 @@ function getApiConfig(overrides?: {
   authMode?: ModelProviderAuthMode;
   model?: string;
   providerProtocol?: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
 }) {
   const defaultEntry = getDefaultModelEntry();
   const defaultProviderGroup = getDefaultProviderGroup();
@@ -282,6 +288,8 @@ function getApiConfig(overrides?: {
     }
     return inferLegacyProviderProtocol({ authMode, apiBase });
   })();
+  const imageInputCapability =
+    overrides?.imageInputCapability || defaultEntry?.imageInputCapability;
 
   if (!apiBase) {
     throw new Error("API URL is missing in preferences");
@@ -297,6 +305,7 @@ function getApiConfig(overrides?: {
       ? `${DEFAULT_SYSTEM_PROMPT}\n\n${customSystemPrompt}`
       : DEFAULT_SYSTEM_PROMPT,
     providerProtocol,
+    imageInputCapability,
   };
 }
 
@@ -1346,9 +1355,22 @@ function buildMessages(
 
 function stripUnsupportedImageContent(
   messages: ChatMessage[],
-  modelName: string,
+  params: {
+    modelName: string;
+    providerProtocol?: ProviderProtocol;
+    authMode?: ModelProviderAuthMode;
+    apiBase?: string;
+    imageInputCapability?: ImageInputCapability;
+  },
 ): ChatMessage[] {
-  if (!isTextOnlyModel(modelName)) return messages;
+  const supportsImages = resolveProviderCapabilities({
+    model: params.modelName,
+    protocol: params.providerProtocol,
+    authMode: params.authMode,
+    apiBase: params.apiBase,
+    imageInputCapability: params.imageInputCapability,
+  }).images;
+  if (supportsImages) return messages;
   return messages.map((message) => {
     if (typeof message.content === "string") return message;
     const omittedImageCount = message.content.filter(
@@ -1362,7 +1384,7 @@ function stripUnsupportedImageContent(
       omittedImageCount > 0
         ? `[${omittedImageCount} image input${
             omittedImageCount === 1 ? "" : "s"
-          } omitted because ${modelName || "the selected model"} does not support image input.]`
+          } omitted because ${params.modelName || "the selected model"} does not support image input.]`
         : "";
     const content = [...textParts, omittedNotice].filter(Boolean).join("\n\n");
     return {
@@ -1373,17 +1395,31 @@ function stripUnsupportedImageContent(
 }
 
 export function prepareChatRequest(params: ChatParams): PreparedChatRequest {
-  const { apiBase, apiKey, authMode, model, systemPrompt, providerProtocol } =
-    getApiConfig({
-      apiBase: params.apiBase,
-      apiKey: params.apiKey,
-      authMode: params.authMode,
-      model: params.model,
-      providerProtocol: params.providerProtocol,
-    });
+  const {
+    apiBase,
+    apiKey,
+    authMode,
+    model,
+    systemPrompt,
+    providerProtocol,
+    imageInputCapability,
+  } = getApiConfig({
+    apiBase: params.apiBase,
+    apiKey: params.apiKey,
+    authMode: params.authMode,
+    model: params.model,
+    providerProtocol: params.providerProtocol,
+    imageInputCapability: params.imageInputCapability,
+  });
   const rawMessages = stripUnsupportedImageContent(
     buildMessages(params, systemPrompt),
-    model,
+    {
+      modelName: model,
+      providerProtocol,
+      authMode,
+      apiBase,
+      imageInputCapability,
+    },
   );
   const inputCap = applyModelInputTokenCap(
     rawMessages,
@@ -2374,9 +2410,7 @@ async function parseAnthropicStreamResponse(
             const outputTokens = parsed.message.usage.output_tokens ?? 0;
             const totalTokens = inputTokens + outputTokens;
             if (inputTokens > 0 || totalTokens > 0) {
-              const cacheUsage = extractContextCacheUsage(
-                parsed.message.usage,
-              );
+              const cacheUsage = extractContextCacheUsage(parsed.message.usage);
               onUsage({
                 promptTokens: inputTokens,
                 completionTokens: outputTokens,
@@ -2548,9 +2582,7 @@ async function parseGeminiNativeStreamResponse(
           if (parsed.usageMetadata && onUsage) {
             const total = parsed.usageMetadata.totalTokenCount ?? 0;
             if (total > 0) {
-              const cacheUsage = extractContextCacheUsage(
-                parsed.usageMetadata,
-              );
+              const cacheUsage = extractContextCacheUsage(parsed.usageMetadata);
               onUsage({
                 promptTokens: parsed.usageMetadata.promptTokenCount ?? 0,
                 completionTokens:

--- a/src/utils/modelProviders.ts
+++ b/src/utils/modelProviders.ts
@@ -10,6 +10,7 @@ import {
   normalizeProviderProtocolForAuthMode,
   type ProviderProtocol,
 } from "./providerProtocol";
+import type { ImageInputCapability } from "../providers";
 import { detectProviderPreset, getProviderPreset } from "./providerPresets";
 import type { ProviderPresetId } from "./providerPresets";
 
@@ -28,6 +29,7 @@ export type AdvancedModelConfig = {
 export type ModelProviderModel = AdvancedModelConfig & {
   id: string;
   model: string;
+  imageInputCapability?: ImageInputCapability;
   /** Per-model protocol override. When set, overrides the group-level protocol. */
   providerProtocol?: ProviderProtocol;
 };
@@ -58,6 +60,7 @@ export type RuntimeModelEntry = {
   apiKey: string;
   authMode: ModelProviderAuthMode;
   providerProtocol: ProviderProtocol;
+  imageInputCapability?: ImageInputCapability;
   providerLabel: string;
   providerOrder: number;
   displayModelLabel: string;
@@ -141,6 +144,13 @@ function normalizeProviderAuthMode(value: unknown): ModelProviderAuthMode {
   if (value === "copilot_auth") return "copilot_auth";
   if (value === "webchat") return "webchat"; // [webchat]
   return "api_key";
+}
+
+function normalizeImageInputCapability(
+  value: unknown,
+): ImageInputCapability | undefined {
+  if (value === "text_only" || value === "vision") return value;
+  return undefined;
 }
 
 function normalizeAdvancedModelConfig(
@@ -279,6 +289,7 @@ function normalizeGroupModel(model: unknown): ModelProviderModel | null {
     temperature?: unknown;
     maxTokens?: unknown;
     inputTokenCap?: unknown;
+    imageInputCapability?: unknown;
     providerProtocol?: unknown;
   };
   const modelName = normalizeString(rawModel.model);
@@ -300,6 +311,13 @@ function normalizeGroupModel(model: unknown): ModelProviderModel | null {
         : createId("model"),
     model: modelName,
     ...advanced,
+    ...(normalizeImageInputCapability(rawModel.imageInputCapability)
+      ? {
+          imageInputCapability: normalizeImageInputCapability(
+            rawModel.imageInputCapability,
+          ),
+        }
+      : {}),
     ...(modelProtocol ? { providerProtocol: modelProtocol } : {}),
   };
 }
@@ -584,12 +602,16 @@ export function createProviderModelEntry(
   model = "",
   advanced?: Partial<AdvancedModelConfig>,
   providerProtocol?: ProviderProtocol,
+  imageInputCapability?: ImageInputCapability,
 ): ModelProviderModel {
   return {
     id: createId("model"),
     model: model.trim(),
     ...normalizeAdvancedModelConfig(advanced, model),
     ...(providerProtocol ? { providerProtocol } : {}),
+    ...(normalizeImageInputCapability(imageInputCapability)
+      ? { imageInputCapability }
+      : {}),
   };
 }
 
@@ -640,6 +662,7 @@ export function getRuntimeModelEntries(): RuntimeModelEntry[] {
         apiKey: group.apiKey.trim(),
         authMode,
         providerProtocol: resolveRuntimeProviderProtocol(group, modelEntry),
+        imageInputCapability: modelEntry.imageInputCapability,
         providerLabel,
         providerOrder: groupIndex,
         displayModelLabel:

--- a/test/llmClient.prepareChatRequest.test.ts
+++ b/test/llmClient.prepareChatRequest.test.ts
@@ -278,6 +278,36 @@ describe("llmClient prepareChatRequest", function () {
     assert.notInclude(JSON.stringify(prepared.messages), "image_url");
   });
 
+  it("strips image content when the configured model is marked text-only", function () {
+    const prepared = prepareChatRequest({
+      prompt: "Describe this image.",
+      images: ["data:image/png;base64,AAAA"],
+      model: "gpt-4o",
+      apiBase: "https://api.openai.com/v1",
+      providerProtocol: "openai_chat_compat",
+      imageInputCapability: "text_only",
+    });
+
+    const lastMessage = prepared.messages[prepared.messages.length - 1];
+    assert.equal(lastMessage.role, "user");
+    assert.isString(lastMessage.content);
+    assert.include(String(lastMessage.content), "image input");
+    assert.notInclude(JSON.stringify(prepared.messages), "image_url");
+  });
+
+  it("keeps image content when a local compatible model is marked vision-capable", function () {
+    const prepared = prepareChatRequest({
+      prompt: "Describe this image.",
+      images: ["data:image/png;base64,AAAA"],
+      model: "llama3.1",
+      apiBase: "http://127.0.0.1:11434/v1",
+      providerProtocol: "openai_chat_compat",
+      imageInputCapability: "vision",
+    });
+
+    assert.include(JSON.stringify(prepared.messages), "image_url");
+  });
+
   it("keeps Anthropic Messages thinking off by default and preserves temperature", async function () {
     let capturedBody: Record<string, unknown> | null = null;
     mockFetch(async (_url, init) => {

--- a/test/llmClient.prepareChatRequest.test.ts
+++ b/test/llmClient.prepareChatRequest.test.ts
@@ -308,6 +308,33 @@ describe("llmClient prepareChatRequest", function () {
     assert.include(JSON.stringify(prepared.messages), "image_url");
   });
 
+  it("strips image content from prior history when marked text-only", function () {
+    const prepared = prepareChatRequest({
+      prompt: "Continue without looking at images.",
+      history: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Earlier image question." },
+            {
+              type: "image_url",
+              image_url: { url: "data:image/png;base64,BBBB", detail: "high" },
+            },
+          ],
+        },
+        { role: "assistant", content: "Earlier answer." },
+      ],
+      model: "third-party-chat",
+      apiBase: "https://api.example.test/v1",
+      providerProtocol: "openai_chat_compat",
+      imageInputCapability: "text_only",
+    });
+
+    assert.notInclude(JSON.stringify(prepared.messages), "image_url");
+    assert.include(JSON.stringify(prepared.messages), "Earlier image question.");
+    assert.include(JSON.stringify(prepared.messages), "image input");
+  });
+
   it("keeps Anthropic Messages thinking off by default and preserves temperature", async function () {
     let capturedBody: Record<string, unknown> | null = null;
     mockFetch(async (_url, init) => {

--- a/test/modelProviders.test.ts
+++ b/test/modelProviders.test.ts
@@ -425,6 +425,52 @@ describe("modelProviders", function () {
     assert.equal(entries[0].displayModelLabel, "codex/gpt-5.4");
   });
 
+  it("preserves per-model image input capability settings", function () {
+    (
+      globalThis.Zotero.Prefs as {
+        set: (key: string, value: unknown, global?: boolean) => void;
+      }
+    ).set(
+      `${config.prefsPrefix}.modelProviderGroups`,
+      JSON.stringify([
+        {
+          id: "provider-local",
+          apiBase: "http://127.0.0.1:11434/v1",
+          apiKey: "local",
+          authMode: "api_key",
+          providerProtocol: "openai_chat_compat",
+          models: [
+            {
+              id: "m1",
+              model: "llama3.1",
+              temperature: 0.3,
+              maxTokens: 4096,
+              imageInputCapability: "text_only",
+            },
+            {
+              id: "m2",
+              model: "llava",
+              temperature: 0.3,
+              maxTokens: 4096,
+              imageInputCapability: "vision",
+            },
+          ],
+        },
+      ]),
+      true,
+    );
+    (
+      globalThis.Zotero.Prefs as {
+        set: (key: string, value: unknown, global?: boolean) => void;
+      }
+    ).set(`${config.prefsPrefix}.modelProviderGroupsMigrationVersion`, 3, true);
+
+    const entries = getRuntimeModelEntries();
+    assert.lengthOf(entries, 2);
+    assert.equal(entries[0].imageInputCapability, "text_only");
+    assert.equal(entries[1].imageInputCapability, "vision");
+  });
+
   it("keeps codex app server entries labeled separately", function () {
     (
       globalThis.Zotero.Prefs as {

--- a/test/providerCapabilities.test.ts
+++ b/test/providerCapabilities.test.ts
@@ -196,4 +196,33 @@ describe("provider capabilities", function () {
       assert.isTrue(isTextOnlyModel(model), model);
     }
   });
+
+  it("lets per-model image input settings override automatic detection", function () {
+    assert.deepInclude(
+      resolveProviderCapabilities({
+        model: "deepseek-chat",
+        apiBase: "https://api.deepseek.com/v1",
+        protocol: "openai_chat_compat",
+        imageInputCapability: "vision",
+      }),
+      {
+        images: true,
+        multimodal: true,
+      },
+    );
+
+    assert.deepInclude(
+      resolveProviderCapabilities({
+        model: "gpt-4o",
+        apiBase: "https://api.openai.com/v1/responses",
+        protocol: "responses_api",
+        imageInputCapability: "text_only",
+      }),
+      {
+        pdf: "none",
+        images: false,
+        multimodal: false,
+      },
+    );
+  });
 });

--- a/test/sendFlowController.test.ts
+++ b/test/sendFlowController.test.ts
@@ -132,6 +132,7 @@ describe("sendFlowController", function () {
     let lastRuntimeMode = "";
     let lastSentAuthMode = "";
     let lastSentProviderProtocol = "";
+    let lastSentImageInputCapability = "";
     let lastSentModelProviderLabel = "";
     let lastSentImages: string[] | undefined;
     let lastSentAttachments: ChatAttachment[] | undefined;
@@ -226,6 +227,7 @@ describe("sendFlowController", function () {
         lastRuntimeMode = opts.runtimeMode || "";
         lastSentAuthMode = opts.authMode || "";
         lastSentProviderProtocol = opts.providerProtocol || "";
+        lastSentImageInputCapability = opts.imageInputCapability || "";
         lastSentModelProviderLabel = opts.modelProviderLabel || "";
         lastSentImages = opts.images;
         lastSentAttachments = opts.attachments;
@@ -296,6 +298,7 @@ describe("sendFlowController", function () {
         lastRuntimeMode,
         lastSentAuthMode,
         lastSentProviderProtocol,
+        lastSentImageInputCapability,
         lastSentModelProviderLabel,
         lastSentImages,
         lastSentAttachments,
@@ -340,6 +343,26 @@ describe("sendFlowController", function () {
     await controller.doSend();
 
     assert.equal(getCounts().composerDraftClearedCalls, 1);
+  });
+
+  it("omits selected screenshots for text-only non-agent sends", async function () {
+    const { controller, getLastSend } = createBaseDeps({
+      getSelectedProfile: () => ({
+        entryId: "entry-text-only",
+        model: "third-party-chat",
+        apiBase: "https://api.example.test/v1",
+        apiKey: "test-key",
+        providerLabel: "Example",
+        authMode: "api_key",
+        providerProtocol: "openai_chat_compat",
+        imageInputCapability: "text_only",
+      }),
+    });
+
+    await controller.doSend();
+
+    assert.deepEqual(getLastSend().lastSentImages, []);
+    assert.equal(getLastSend().lastSentImageInputCapability, "text_only");
   });
 
   it("awaits the resolved context source before selecting paper contexts", async function () {


### PR DESCRIPTION
## Summary
- add a per-model Image input setting with `auto`, Text only, and Supports images options
- thread the image input override through chat, agent, and provider capability resolution
- strip image content with an explanatory notice when the selected model is treated as text-only
- fix non-agent chat mode so selected screenshots are also omitted when the selected model is configured as Text only

## Why
Agent mode can receive image artifacts from tool calls, for example after reading figures or screenshots. When the selected model does not support multimodal input, those image blocks can make the next model request fail and interrupt the agent run.

Non-agent chat mode had the same class of problem for manually selected screenshots: parts of the send path still used the old model-name-only screenshot check, so a provider/model explicitly configured as Text only could still send image payloads and trigger upstream 502 errors on non-multimodal endpoints.

Automatic model-name detection is not always enough for OpenAI-compatible providers and proxy models. This change lets users explicitly mark a model as text-only or image-capable while keeping `auto` as the default behavior.

## User impact
Users can set Image input to Text only for models that cannot process images, preventing both agent-mode image reads and normal chat screenshots from breaking the conversation. Users can also force Supports images when a compatible model is misdetected as text-only.

## Validation
- `PATH="/opt/homebrew/Cellar/node@24/24.14.0/bin:$PATH" npm run test:unit -- test/sendFlowController.test.ts test/llmClient.prepareChatRequest.test.ts test/providerCapabilities.test.ts test/modelProviders.test.ts`
- `PATH="/opt/homebrew/Cellar/node@24/24.14.0/bin:$PATH" npm run build`
