### PR TITLE
feat: add provider protocol selection to preference UI

### DIFF
--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -1167,6 +1167,48 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
       );
       apiUrlWrap.append(apiUrlLabel, apiUrlInput, apiUrlHelper);
 
+      // ── Provider protocol ──────────────────────────────────────────
+      const protocolWrap = el(
+        doc,
+        "div",
+        "display: flex; flex-direction: column;",
+      );
+      const protocolLabel = el(doc, "label", LABEL_STYLE, t("API protocol"));
+      const protocolSelect = el(
+        doc,
+        "select",
+        INPUT_STYLE,
+      ) as HTMLSelectElement;
+      protocolSelect.id = `${config.addonRef}-provider-protocol-${group.id}`;
+      protocolLabel.setAttribute("for", protocolSelect.id);
+      const providerProtocolOptions = getProtocolOptions(
+        group.authMode,
+        selectedPresetId,
+      );
+      for (const protocol of providerProtocolOptions) {
+        const option = el(doc, "option") as HTMLOptionElement;
+        option.value = protocol;
+        option.textContent = getProviderProtocolSpec(protocol).label;
+        option.selected = protocol === group.providerProtocol;
+        protocolSelect.appendChild(option);
+      }
+      protocolSelect.value = group.providerProtocol;
+      protocolSelect.addEventListener("change", () => {
+        if (!isProviderProtocol(protocolSelect.value)) return;
+        group.providerProtocol = protocolSelect.value;
+        protocolHelper.textContent = t(
+          getProviderProtocolSpec(group.providerProtocol).helperText,
+        );
+        persistGroups(groups);
+      });
+      const protocolHelper = el(
+        doc,
+        "span",
+        HELPER_STYLE,
+        t(getProviderProtocolSpec(group.providerProtocol).helperText),
+      );
+      protocolWrap.append(protocolLabel, protocolSelect, protocolHelper);
+
       // ── API Key ──────────────────────────────────────────────────
       const apiKeyWrap = el(
         doc,
@@ -1957,6 +1999,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
           authModeWrap,
           providerPresetWrap,
           apiUrlWrap,
+          ...(isCustomizedPreset ? [protocolWrap] : []),
           apiKeyWrap,
           divider,
           modelsWrap,


### PR DESCRIPTION
**Summary**
This PR adds provider protocol selection to the preferences UI for customized provider presets.

**What changed**
Added a new protocol dropdown in the provider settings section.
The selected protocol is persisted alongside the existing provider group settings.
The helper text updates dynamically based on the chosen protocol.
The protocol selector is shown only for customized presets, keeping the default experience unchanged.

**Why**
Some provider presets require explicitly selecting a protocol. This change makes that configuration available in the UI instead of relying on implicit defaults.

**Testing**
Local testing completed successfully on this branch.
Verified that the new selector appears for customized presets and that the selected value is saved correctly.



from 
<img width="581" height="552" alt="截屏2026-06-24 17 00 14" src="https://github.com/user-attachments/assets/d4eb0ae8-fa60-4b06-a562-f1dae2fca5ee" />

to 
<img width="776" height="601" alt="截屏2026-06-24 18 20 42" src="https://github.com/user-attachments/assets/0cfb42ba-b313-4eaf-b653-05d188c6d961" />

