### PR TITLE
Add xhigh reasoning option for gpt-5.5

### DIFF
--- a/src/utils/reasoningProfiles.ts
+++ b/src/utils/reasoningProfiles.ts
@@ -624,7 +624,7 @@ const PROFILE_RULES: Record<
         profile: OPENAI_GPT5_CODEX_PROFILE,
       },
       {
-        match: /^gpt-5\.4(?:\b|[.-])/,
+        match: /^gpt-5\.(?:4|5)(?:\b|[.-])/,
         profile: OPENAI_GPT5_XHIGH_PROFILE,
       },
       {


### PR DESCRIPTION
## Summary

- map `gpt-5.5` to the OpenAI reasoning profile that exposes `xhigh`

## Why

`gpt-5.5` currently falls through to the generic `gpt-5` profile, so the UI does not offer the `xhigh` reasoning effort even though adjacent GPT-5 point releases do.

## Validation

- checked the compare diff is one file with one line changed
- verified `gpt-5.5` resolves to reasoning options including `xhigh`
