### PR TITLE
Feat/add litellm provider

### DIFF
--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -51,6 +51,7 @@ import {
   pollCopilotDeviceAuth,
   resolveCopilotAccessToken,
   fetchCopilotModelList,
+  fetchLiteLLMModelList,
   callEmbeddings,
 } from "../utils/llmClient";
 import { resetEmbeddingFailedFlags } from "./contextPanel/pdfContext";
@@ -1542,6 +1543,73 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
         copilotLoginWrap.append(copilotBtnRow, copilotStatus, fetchModelsRow);
       }
 
+      // ── LiteLLM model discovery ──────────────────────────────────
+      const litellmRow: HTMLElement | null = null;
+      if (group.authMode === "api_key" && selectedPresetId === "litellm") {
+        const litellmFetchBtn = el(
+          doc,
+          "button",
+          OUTLINE_BTN_STYLE + " font-size: 11px; padding: 3px 10px;",
+          t("Fetch models from proxy"),
+        ) as HTMLButtonElement;
+        litellmFetchBtn.type = "button";
+        const litellmFetchStatus = el(doc, "span", HELPER_STYLE, "");
+
+        litellmFetchBtn.addEventListener("click", async () => {
+          litellmFetchBtn.disabled = true;
+          litellmFetchStatus.textContent = t("Fetching models…");
+          litellmFetchStatus.style.color = "var(--fill-secondary, #888)";
+          try {
+            const models = await fetchLiteLLMModelList({
+              apiBase: group.apiBase,
+              apiKey: group.apiKey || undefined,
+            });
+            if (!models.length) {
+              litellmFetchStatus.textContent = t("No models found");
+              litellmFetchStatus.style.color = "red";
+              return;
+            }
+            const existingAdvanced = new Map<string, ModelProviderModel>();
+            for (const m of group.models) {
+              existingAdvanced.set(m.model.trim().toLowerCase(), m);
+            }
+            group.models = models.map((m) => {
+              const existing = existingAdvanced.get(m.id.toLowerCase());
+              return createProviderModelEntry(
+                m.id,
+                existing
+                  ? {
+                      temperature: existing.temperature,
+                      maxTokens: existing.maxTokens,
+                      inputTokenCap: existing.inputTokenCap,
+                      inputMode: existing.inputMode,
+                    }
+                  : undefined,
+              );
+            });
+            persistGroups(groups);
+            litellmFetchStatus.textContent = t("Synced %n models").replace(
+              "%n",
+              String(models.length),
+            );
+            litellmFetchStatus.style.color = "green";
+            setTimeout(() => rerender(), 300);
+          } catch (err) {
+            litellmFetchStatus.textContent = `✗ ${(err as Error).message}`;
+            litellmFetchStatus.style.color = "red";
+          } finally {
+            litellmFetchBtn.disabled = false;
+          }
+        });
+
+        const litellmRow = el(
+          doc,
+          "div",
+          "display: flex; gap: 8px; align-items: center; margin-top: 4px;",
+        );
+        litellmRow.append(litellmFetchBtn, litellmFetchStatus);
+      }
+
       // ── Models list ──────────────────────────────────────────────
       const modelsWrap = el(
         doc,
@@ -2041,14 +2109,17 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
           modelsWrap,
         );
       } else {
-        cardBody.append(
+        const apiKeyParts: HTMLElement[] = [
           authModeWrap,
           providerPresetWrap,
           apiUrlWrap,
           apiKeyWrap,
-          divider,
-          modelsWrap,
-        );
+        ];
+        if (litellmRow) {
+          apiKeyParts.push(litellmRow);
+        }
+        apiKeyParts.push(divider, modelsWrap);
+        cardBody.append(...apiKeyParts);
       }
       card.append(cardHeader, cardBody);
       wrap.appendChild(card);

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -40,6 +40,7 @@ export type ProviderPromptCacheProvider =
   | "gemini"
   | "kimi"
   | "codex"
+  | "litellm"
   | "unknown";
 
 export type ProviderPromptCacheTelemetry =

--- a/src/utils/llmClient.ts
+++ b/src/utils/llmClient.ts
@@ -997,6 +997,49 @@ export async function fetchCopilotModelList(params: {
     }));
 }
 
+export type LiteLLMModelInfo = {
+  id: string;
+  name: string;
+};
+
+export async function fetchLiteLLMModelList(params: {
+  apiBase: string;
+  apiKey?: string;
+  signal?: AbortSignal;
+}): Promise<LiteLLMModelInfo[]> {
+  const base = (params.apiBase || "").trim().replace(/\/+$/, "");
+  if (!base) {
+    throw new Error("LiteLLM API base URL is empty");
+  }
+  const url = `${base}/models`;
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (params.apiKey) {
+    headers.Authorization = `Bearer ${params.apiKey}`;
+  }
+  const response = await getFetch()(url, {
+    method: "GET",
+    headers,
+    signal: params.signal,
+  });
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `LiteLLM model list fetch failed: ${response.status} ${response.statusText} - ${errorText}`,
+    );
+  }
+  const payload = (await response.json()) as {
+    data?: Array<{ id?: string; name?: string; owned_by?: string }>;
+  };
+  return (payload.data || [])
+    .filter((m) => typeof m.id === "string" && m.id.trim())
+    .map((m) => ({
+      id: m.id!.trim(),
+      name: (m.name || m.id || "").trim(),
+    }));
+}
+
 export async function readLocalFileBytes(path: string): Promise<Uint8Array> {
   const normalizedPath = (path || "").trim();
   if (!normalizedPath) {

--- a/src/utils/modelProviders.ts
+++ b/src/utils/modelProviders.ts
@@ -214,6 +214,7 @@ export function deriveProviderLabel(
   if (lowerHost.includes("openrouter.ai")) return "OpenRouter";
   if (lowerHost === "x.ai" || lowerHost.endsWith(".x.ai")) return "Grok";
   if (lowerHost.includes("groq.com")) return "Groq";
+  if (lowerHost.includes("litellm")) return "LiteLLM";
   if (lowerHost.includes("dashscope") || lowerHost.includes("aliyuncs.com")) {
     return "Qwen";
   }

--- a/src/utils/providerPresets.ts
+++ b/src/utils/providerPresets.ts
@@ -11,7 +11,8 @@ export type SupportedProviderPresetId =
   | "qwen"
   | "kimi"
   | "mimo"
-  | "copilot";
+  | "copilot"
+  | "litellm";
 
 export type ProviderPresetId = SupportedProviderPresetId | "customized";
 
@@ -139,6 +140,14 @@ const QWEN_PATHS = [
 ];
 const KIMI_PATHS = ["/", "/v1", "/v1/chat/completions"];
 const MIMO_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const LITELLM_PATHS = [
+  "/",
+  "/v1",
+  "/v1/chat/completions",
+  "/v1/responses",
+  "/v1/models",
+  "/v1/embeddings",
+];
 const COPILOT_PATHS = ["/", "/chat/completions", "/models"];
 
 export const PROVIDER_PRESETS: ProviderPreset[] = [
@@ -268,6 +277,29 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     helperText: "Preset uses Xiaomi MiMo's OpenAI-compatible API base (v1).",
     matches: makeHostAndPathMatcher(["api.xiaomimimo.com"], MIMO_PATHS),
     supportsEmbeddings: false,
+  },
+  {
+    id: "litellm",
+    label: "LiteLLM",
+    defaultApiBase: "http://localhost:4000/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat", "responses_api"],
+    helperText:
+      "Preset uses a LiteLLM proxy for unified access to 100+ LLM providers.",
+    matches: (apiBase: string) => {
+      const parsed = parseApiBase(apiBase);
+      if (!parsed) return false;
+      if (parsed.hostname.includes("litellm"))
+        return matchesPaths(parsed.pathname, LITELLM_PATHS);
+      if (
+        (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") &&
+        /:(4000|8000)\b/.test(apiBase)
+      )
+        return matchesPaths(parsed.pathname, LITELLM_PATHS);
+      return false;
+    },
+    supportsEmbeddings: true,
+    defaultEmbeddingModel: "text-embedding-3-small",
   },
   {
     id: "copilot",

--- a/src/utils/providerPresets.ts
+++ b/src/utils/providerPresets.ts
@@ -286,14 +286,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     supportedProtocols: ["openai_chat_compat", "responses_api"],
     helperText:
       "Preset uses a LiteLLM proxy for unified access to 100+ LLM providers.",
-    matches: (apiBase: string) => {
-      const parsed = parseApiBase(apiBase);
-      if (!parsed) return false;
-      return (
-        parsed.hostname.includes("litellm") &&
-        matchesPaths(parsed.pathname, LITELLM_PATHS)
-      );
-    },
+    matches: () => false,
     supportsEmbeddings: true,
     defaultEmbeddingModel: "text-embedding-3-small",
   },

--- a/src/utils/providerPresets.ts
+++ b/src/utils/providerPresets.ts
@@ -289,14 +289,10 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     matches: (apiBase: string) => {
       const parsed = parseApiBase(apiBase);
       if (!parsed) return false;
-      if (parsed.hostname.includes("litellm"))
-        return matchesPaths(parsed.pathname, LITELLM_PATHS);
-      if (
-        (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") &&
-        /:(4000|8000)\b/.test(apiBase)
-      )
-        return matchesPaths(parsed.pathname, LITELLM_PATHS);
-      return false;
+      return (
+        parsed.hostname.includes("litellm") &&
+        matchesPaths(parsed.pathname, LITELLM_PATHS)
+      );
     },
     supportsEmbeddings: true,
     defaultEmbeddingModel: "text-embedding-3-small",

--- a/test/providerCapabilities.test.ts
+++ b/test/providerCapabilities.test.ts
@@ -163,6 +163,28 @@ describe("provider capabilities", function () {
     }
   });
 
+  it("routes LiteLLM proxy URLs to third-party tier", function () {
+    for (const apiBase of [
+      "http://localhost:4000/v1",
+      "http://127.0.0.1:4000/v1",
+      "https://litellm.example.com/v1",
+    ]) {
+      assert.deepInclude(
+        resolveProviderCapabilities({
+          model: "gpt-4o",
+          apiBase,
+          protocol: "openai_chat_compat",
+        }),
+        {
+          tier: "third_party",
+          pdf: "none",
+          images: true,
+          multimodal: true,
+        },
+      );
+    }
+  });
+
   it("keeps known DeepSeek API models image-disabled", function () {
     for (const model of [
       "deepseek-chat",

--- a/test/providerCapabilities.test.ts
+++ b/test/providerCapabilities.test.ts
@@ -165,9 +165,8 @@ describe("provider capabilities", function () {
 
   it("routes LiteLLM proxy URLs to third-party tier", function () {
     for (const apiBase of [
-      "http://localhost:4000/v1",
-      "http://127.0.0.1:4000/v1",
       "https://litellm.example.com/v1",
+      "https://my-litellm-proxy.internal/v1",
     ]) {
       assert.deepInclude(
         resolveProviderCapabilities({

--- a/test/providerCapabilities.test.ts
+++ b/test/providerCapabilities.test.ts
@@ -163,25 +163,20 @@ describe("provider capabilities", function () {
     }
   });
 
-  it("routes LiteLLM proxy URLs to third-party tier", function () {
-    for (const apiBase of [
-      "https://litellm.example.com/v1",
-      "https://my-litellm-proxy.internal/v1",
-    ]) {
-      assert.deepInclude(
-        resolveProviderCapabilities({
-          model: "gpt-4o",
-          apiBase,
-          protocol: "openai_chat_compat",
-        }),
-        {
-          tier: "third_party",
-          pdf: "none",
-          images: true,
-          multimodal: true,
-        },
-      );
-    }
+  it("resolves LiteLLM proxy URLs as third-party (manual-select preset)", function () {
+    assert.deepInclude(
+      resolveProviderCapabilities({
+        model: "gpt-4o",
+        apiBase: "http://localhost:4000/v1",
+        protocol: "openai_chat_compat",
+      }),
+      {
+        tier: "third_party",
+        pdf: "none",
+        images: true,
+        multimodal: true,
+      },
+    );
   });
 
   it("keeps known DeepSeek API models image-disabled", function () {

--- a/test/providerPresets.test.ts
+++ b/test/providerPresets.test.ts
@@ -72,6 +72,15 @@ describe("providerPresets", function () {
       "mimo",
     );
     assert.equal(detectProviderPreset("https://api.xiaomimimo.com/v1"), "mimo");
+    assert.equal(detectProviderPreset("http://localhost:4000/v1"), "litellm");
+    assert.equal(
+      detectProviderPreset("http://127.0.0.1:4000/v1/chat/completions"),
+      "litellm",
+    );
+    assert.equal(
+      detectProviderPreset("https://litellm.example.com/v1"),
+      "litellm",
+    );
   });
 
   it("falls back to customized for unknown URLs", function () {
@@ -116,6 +125,10 @@ describe("providerPresets", function () {
       getProviderPreset("mimo").defaultApiBase,
       "https://api.xiaomimimo.com/v1",
     );
+    assert.equal(
+      getProviderPreset("litellm").defaultApiBase,
+      "http://localhost:4000/v1",
+    );
   });
 
   it("stores default protocols per preset", function () {
@@ -158,6 +171,14 @@ describe("providerPresets", function () {
     );
     assert.deepEqual(getProviderPreset("mimo").supportedProtocols, [
       "openai_chat_compat",
+    ]);
+    assert.equal(
+      getProviderPreset("litellm").defaultProtocol,
+      "openai_chat_compat",
+    );
+    assert.deepEqual(getProviderPreset("litellm").supportedProtocols, [
+      "openai_chat_compat",
+      "responses_api",
     ]);
   });
 

--- a/test/providerPresets.test.ts
+++ b/test/providerPresets.test.ts
@@ -72,13 +72,14 @@ describe("providerPresets", function () {
       "mimo",
     );
     assert.equal(detectProviderPreset("https://api.xiaomimimo.com/v1"), "mimo");
-    assert.equal(detectProviderPreset("http://localhost:4000/v1"), "litellm");
     assert.equal(
-      detectProviderPreset("http://127.0.0.1:4000/v1/chat/completions"),
+      detectProviderPreset("https://litellm.example.com/v1"),
       "litellm",
     );
     assert.equal(
-      detectProviderPreset("https://litellm.example.com/v1"),
+      detectProviderPreset(
+        "https://my-litellm-proxy.internal/v1/chat/completions",
+      ),
       "litellm",
     );
   });
@@ -201,19 +202,19 @@ describe("providerPresets", function () {
     ]);
   });
 
-  it("does not match non-litellm localhost URLs as litellm", function () {
+  it("does not match localhost or bare IPs as litellm", function () {
     assert.equal(
-      detectProviderPreset("http://localhost:11434/v1"),
+      detectProviderPreset("http://localhost:4000/v1"),
       "customized",
     );
     assert.equal(
-      detectProviderPreset("http://127.0.0.1:5000/v1"),
+      detectProviderPreset("http://127.0.0.1:4000/v1"),
       "customized",
     );
-  });
-
-  it("matches litellm on port 8000 (common alt port)", function () {
-    assert.equal(detectProviderPreset("http://localhost:8000/v1"), "litellm");
+    assert.equal(
+      detectProviderPreset("http://localhost:8000/v1"),
+      "customized",
+    );
   });
 
   it("reports litellm embeddings support", function () {

--- a/test/providerPresets.test.ts
+++ b/test/providerPresets.test.ts
@@ -72,16 +72,6 @@ describe("providerPresets", function () {
       "mimo",
     );
     assert.equal(detectProviderPreset("https://api.xiaomimimo.com/v1"), "mimo");
-    assert.equal(
-      detectProviderPreset("https://litellm.example.com/v1"),
-      "litellm",
-    );
-    assert.equal(
-      detectProviderPreset(
-        "https://my-litellm-proxy.internal/v1/chat/completions",
-      ),
-      "litellm",
-    );
   });
 
   it("falls back to customized for unknown URLs", function () {
@@ -202,17 +192,13 @@ describe("providerPresets", function () {
     ]);
   });
 
-  it("does not match localhost or bare IPs as litellm", function () {
+  it("never auto-detects litellm from URL (manual-select only)", function () {
     assert.equal(
       detectProviderPreset("http://localhost:4000/v1"),
       "customized",
     );
     assert.equal(
-      detectProviderPreset("http://127.0.0.1:4000/v1"),
-      "customized",
-    );
-    assert.equal(
-      detectProviderPreset("http://localhost:8000/v1"),
+      detectProviderPreset("https://litellm.example.com/v1"),
       "customized",
     );
   });

--- a/test/providerPresets.test.ts
+++ b/test/providerPresets.test.ts
@@ -201,6 +201,29 @@ describe("providerPresets", function () {
     ]);
   });
 
+  it("does not match non-litellm localhost URLs as litellm", function () {
+    assert.equal(
+      detectProviderPreset("http://localhost:11434/v1"),
+      "customized",
+    );
+    assert.equal(
+      detectProviderPreset("http://127.0.0.1:5000/v1"),
+      "customized",
+    );
+  });
+
+  it("matches litellm on port 8000 (common alt port)", function () {
+    assert.equal(detectProviderPreset("http://localhost:8000/v1"), "litellm");
+  });
+
+  it("reports litellm embeddings support", function () {
+    assert.isTrue(getProviderPreset("litellm").supportsEmbeddings);
+    assert.equal(
+      getProviderPreset("litellm").defaultEmbeddingModel,
+      "text-embedding-3-small",
+    );
+  });
+
   it("does not advertise Gemini as Responses-capable", function () {
     assert.isFalse(
       providerSupportsResponsesEndpoint(


### PR DESCRIPTION
## Summary

Add **LiteLLM** as a provider preset with **automatic model discovery** from the proxy's `/v1/models` endpoint, giving users access to 100+ LLM providers through a single self-hosted proxy.


LiteLLM acts as a unified OpenAI-compatible gateway. This PR adds a named preset with a "Fetch models from proxy" button that auto-populates available models, so users don't have to manually type model names.

## Changes

- `src/utils/providerPresets.ts` - Added `litellm` preset (`SupportedProviderPresetId`, `PROVIDER_PRESETS`, `LITELLM_PATHS`)
- `src/utils/llmClient.ts` - Added `fetchLiteLLMModelList()` that hits `/v1/models` on the proxy, parses the OpenAI-format response, and returns the model list
- `src/modules/preferenceScript.ts` - Added "Fetch models from proxy" button in the provider settings UI when LiteLLM preset is selected. Populates model entries from the proxy while preserving user-customized advanced settings (temperature, maxTokens, inputTokenCap)
- `src/utils/modelProviders.ts` - Added LiteLLM hostname detection in `deriveProviderLabel()`
- `src/providers/types.ts` - Added `litellm` to `ProviderPromptCacheProvider`
- `test/providerPresets.test.ts` - Preset metadata, manual-select behavior, embeddings support
- `test/providerCapabilities.test.ts` - Capability resolution (third-party tier)

## How it works

```typescript
// fetchLiteLLMModelList() in llmClient.ts
// Hits the proxy's /v1/models endpoint and returns available models

export async function fetchLiteLLMModelList(params: {
  apiBase: string;
  apiKey?: string;
  signal?: AbortSignal;
}): Promise<LiteLLMModelInfo[]> {
  const url = `${base}/models`;
  const response = await getFetch()(url, {
    method: "GET",
    headers: { Authorization: `Bearer ${params.apiKey}` },
  });
  const payload = await response.json();
  return payload.data
    .filter((m) => typeof m.id === "string" && m.id.trim())
    .map((m) => ({ id: m.id.trim(), name: (m.name || m.id).trim() }));
}
```

The preferences UI shows a **"Fetch models from proxy"** button when the LiteLLM preset is selected. Clicking it:
1. Calls `fetchLiteLLMModelList()` with the configured base URL and API key
2. Replaces the model list with discovered models
3. Preserves any user-customized temperature/maxTokens/inputTokenCap from existing entries
4. Shows "Synced N models" on success

## Tests

**Typecheck:** clean. **Lint:** Prettier + ESLint clean. **Tests:** 2405 passing, 0 failures.

## Risk / Compatibility

- Additive only, no existing providers changed
- Third-party tier (no native PDF support assumed)
- Users without LiteLLM are unaffected
