### PR TITLE
feat: Collapse agent activity and show elapsed task time

### DIFF
--- a/addon/content/zoteroPane.css
+++ b/addon/content/zoteroPane.css
@@ -4089,6 +4089,54 @@
   gap: 10px;
 }
 
+.llm-agent-activity-details {
+  margin: 0;
+}
+
+.llm-agent-activity-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 24px;
+  padding: 2px 0;
+  list-style: none;
+  color: var(--fill-tertiary);
+  font-size: var(--llm-fs-11);
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+}
+
+.llm-agent-activity-summary::-webkit-details-marker {
+  display: none;
+}
+
+.llm-agent-activity-summary::after {
+  content: "›";
+  display: inline-block;
+  font-size: var(--llm-fs-14);
+  line-height: 1;
+  transform-origin: 50% 52%;
+  transition: transform 120ms ease;
+}
+
+.llm-agent-activity-details[open] > .llm-agent-activity-summary::after {
+  transform: rotate(90deg);
+}
+
+.llm-agent-activity-summary:hover,
+.llm-agent-activity-summary:focus-visible {
+  color: var(--fill-secondary);
+  outline: none;
+}
+
+.llm-agent-activity-details > .llm-agent-activity-list {
+  margin-top: 4px;
+  padding-left: 10px;
+  border-left: 1px solid
+    color-mix(in srgb, var(--stroke-secondary) 72%, transparent);
+}
+
 .llm-agent-activity-list {
   display: flex;
   flex-direction: column;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -325,6 +325,7 @@ export type AgentEvent =
       itemId: string;
       text: string;
       status?: "running" | "completed";
+      kind?: "assistant_message";
     }
   | {
       type: "codex_tool_activity";
@@ -354,7 +355,7 @@ export type AgentEvent =
     }
   | { type: "context_compacted"; automatic?: boolean }
   | { type: "fallback"; reason: string }
-  | { type: "final"; text: string };
+  | { type: "final"; text: string; answerStartedAt?: number };
 
 export type AgentRunStatus = "running" | "completed" | "failed" | "cancelled";
 

--- a/src/modules/contextPanel/agentTrace/render.ts
+++ b/src/modules/contextPanel/agentTrace/render.ts
@@ -56,6 +56,10 @@ type AgentTraceSummaryRow = {
 };
 
 const agentTraceActionExpandedCache = new Map<string, boolean>();
+const agentActivityExpandedCache = new WeakMap<
+  Message,
+  { open: boolean; wasWorking: boolean }
+>();
 
 type AgentTraceDisplayItem =
   | {
@@ -96,6 +100,97 @@ type RenderAgentTraceParams = {
   onTraceMissing?: () => void;
   onInterleavedText?: () => void;
 };
+
+export function formatAgentActivityDuration(durationMs: number): string {
+  const totalSeconds = Math.max(
+    1,
+    Math.round((Number.isFinite(durationMs) ? durationMs : 0) / 1000),
+  );
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return [
+    hours > 0 ? `${hours}h` : "",
+    minutes > 0 ? `${minutes}m` : "",
+    `${seconds}s`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function resolveAgentActivityDurationMs(
+  message: Message,
+  userMessage: Message | null | undefined,
+  events: AgentRunEventRecord[],
+  answerStartedAt?: number,
+): number {
+  const eventTimes = events
+    .map((event) => Number(event.createdAt))
+    .filter((value) => Number.isFinite(value) && value > 0);
+  const start = eventTimes.length
+    ? Math.min(...eventTimes)
+    : Number(message.waitingAnimationStartedAt) ||
+      Number(userMessage?.timestamp) ||
+      Number(message.timestamp) ||
+      Date.now();
+  const end =
+    Number.isFinite(answerStartedAt) && Number(answerStartedAt) > 0
+      ? Number(answerStartedAt)
+      : message.streaming
+        ? Date.now()
+        : eventTimes.length
+          ? Math.max(...eventTimes)
+          : Number(message.timestamp) || Date.now();
+  return Math.max(0, end - start);
+}
+
+function appendAgentActivityDisclosure(params: {
+  doc: Document;
+  wrap: HTMLElement;
+  list: HTMLElement;
+  message: Message;
+  userMessage?: Message | null;
+  events: AgentRunEventRecord[];
+  answerStartedAt?: number;
+  forceOpen?: boolean;
+}): void {
+  const { doc, wrap, list, message, userMessage, events } = params;
+  const working = message.streaming === true && !params.answerStartedAt;
+  const previous = agentActivityExpandedCache.get(message);
+  const state = working
+    ? !previous || !previous.wasWorking
+      ? { open: true, wasWorking: true }
+      : previous
+    : previous?.wasWorking
+      ? { open: false, wasWorking: false }
+      : previous || { open: false, wasWorking: false };
+  agentActivityExpandedCache.set(message, state);
+
+  const details = doc.createElement("details") as HTMLDetailsElement;
+  details.className = "llm-agent-activity-details";
+  details.open = params.forceOpen === true || state.open;
+
+  const summary = doc.createElement("summary") as HTMLElement;
+  summary.className = "llm-agent-activity-summary";
+  summary.textContent = working
+    ? "Working…"
+    : `Worked for ${formatAgentActivityDuration(
+        resolveAgentActivityDurationMs(
+          message,
+          userMessage,
+          events,
+          params.answerStartedAt,
+        ),
+      )}`;
+  details.append(summary, list);
+  details.addEventListener("toggle", () => {
+    agentActivityExpandedCache.set(message, {
+      open: details.open,
+      wasWorking: working,
+    });
+  });
+  wrap.appendChild(details);
+}
 
 export function buildAgentTraceMarkdownForRender(
   text: string,
@@ -3506,6 +3601,14 @@ function appendCodexAgentTraceEvent(
     case "codex_progress": {
       const progressText = readAgentTraceText(entry.payload.text);
       if (progressText) {
+        if (entry.payload.kind === "assistant_message") {
+          appendInterleavedInlineText(
+            ctx.items,
+            progressText,
+            ctx.visibleInlineText,
+          );
+          return true;
+        }
         ctx.items.push({
           type: "message",
           tone: "neutral",
@@ -3770,14 +3873,19 @@ export function renderAgentTrace({
     loadingText.textContent = "Loading agent activity...";
     loadingRow.append(loadingIcon, loadingText);
     list.appendChild(loadingRow);
-    wrap.appendChild(list);
+    appendAgentActivityDisclosure({
+      doc,
+      wrap,
+      list,
+      message,
+      userMessage,
+      events,
+      forceOpen: true,
+    });
     return wrap;
   }
-  const {
-    items: processItems,
-    isInterleaved,
-    inlineTextReplacesAssistantText,
-  } = buildAgentTraceDisplayItems(events, userMessage, message);
+  const { items: processItems, inlineTextReplacesAssistantText } =
+    buildAgentTraceDisplayItems(events, userMessage, message);
   if (inlineTextReplacesAssistantText) {
     onInterleavedText?.();
   }
@@ -3788,6 +3896,23 @@ export function renderAgentTrace({
   const hasFinalResponse = events.some(
     (entry) => entry.payload.type === "final",
   );
+  const completedAnswerEvent = events.find(
+    (
+      entry,
+    ): entry is AgentRunEventRecord & {
+      payload: Extract<AgentRunEventRecord["payload"], { type: "final" }>;
+    } =>
+      entry.payload.type === "final" &&
+      Number.isFinite(entry.payload.answerStartedAt),
+  );
+  const answerStartedAt =
+    events.find(
+      (entry) =>
+        entry.payload.type === "codex_progress" &&
+        entry.payload.kind === "assistant_message" &&
+        Boolean(entry.payload.text.trim()),
+    )?.createdAt || completedAnswerEvent?.payload.answerStartedAt;
+  const outputFragments: HTMLElement[] = [];
   for (const [itemIndex, itemEntry] of processItems.entries()) {
     if (itemEntry.type === "inline_text") {
       const inlineEl = doc.createElement("div");
@@ -3801,7 +3926,7 @@ export function renderAgentTrace({
       } catch {
         inlineEl.textContent = inlineText;
       }
-      list.appendChild(inlineEl);
+      outputFragments.push(inlineEl);
       continue;
     }
 
@@ -3951,13 +4076,26 @@ export function renderAgentTrace({
 
     list.appendChild(actionWrap);
   }
-  wrap.appendChild(list);
+  appendAgentActivityDisclosure({
+    doc,
+    wrap,
+    list,
+    message,
+    userMessage,
+    events,
+    answerStartedAt,
+    forceOpen: Boolean(pending),
+  });
 
-  if (hasFinalResponse && !isInterleaved) {
+  if (hasFinalResponse || answerStartedAt) {
     const divider = doc.createElement("div");
     divider.className = "llm-agent-output-divider";
     divider.setAttribute("aria-hidden", "true");
     wrap.appendChild(divider);
+  }
+
+  for (const fragment of outputFragments) {
+    wrap.appendChild(fragment);
   }
 
   if (pending) {

--- a/src/modules/contextPanel/chat.ts
+++ b/src/modules/contextPanel/chat.ts
@@ -4098,8 +4098,10 @@ function createCodexNativeActivityTraceController(
   const mcpRequestToolItemIds = new Map<string, string>();
   const activatedSkillIds = new Set<string>();
   const progressCoalescers = new Map<string, BlockStreamCoalescer>();
+  const agentMessageItemIds = new Set<string>();
   let seq = 0;
   let lastAgentMessageItemId = "";
+  let agentAnswerStartedAt: number | undefined;
 
   const createEvent = (payload: AgentEvent): AgentRunEventRecord => ({
     runId,
@@ -4144,6 +4146,7 @@ function createCodexNativeActivityTraceController(
     text: string,
     mode: "replace" | "append",
     status: "running" | "completed",
+    kind?: "assistant_message",
   ): boolean => {
     const cleanItemId = sanitizeText(itemId).trim();
     const cleanText = sanitizeText(text);
@@ -4163,8 +4166,10 @@ function createCodexNativeActivityTraceController(
           itemId: cleanItemId,
           text: nextText,
           status,
+          ...(kind || existing.payload.kind
+            ? { kind: kind || existing.payload.kind }
+            : {}),
         },
-        createdAt: Date.now(),
       };
       return true;
     }
@@ -4175,6 +4180,7 @@ function createCodexNativeActivityTraceController(
         itemId: cleanItemId,
         text: cleanText,
         status,
+        ...(kind ? { kind } : {}),
       }),
     );
     return true;
@@ -4185,7 +4191,13 @@ function createCodexNativeActivityTraceController(
     if (coalescer) return coalescer;
     coalescer = createBlockStreamCoalescer({
       onBlock: (block) => {
-        const changed = upsertProgressText(itemId, block, "append", "running");
+        const changed = upsertProgressText(
+          itemId,
+          block,
+          "append",
+          "running",
+          agentMessageItemIds.has(itemId) ? "assistant_message" : undefined,
+        );
         if (changed) sync();
       },
     });
@@ -4566,7 +4578,11 @@ function createCodexNativeActivityTraceController(
     event: CodexNativeTraceItemEvent,
     phase: "started" | "completed",
   ): void => {
-    if (isCodexNativeAgentMessageItem(event)) return;
+    if (isCodexNativeAgentMessageItem(event)) {
+      const itemId = sanitizeText(event.id || "").trim();
+      if (itemId) agentMessageItemIds.add(itemId);
+      return;
+    }
     flushAllProgressCoalescers("event");
     if (appendStructuredOperationStatus(event, phase)) {
       sync();
@@ -4616,6 +4632,19 @@ function createCodexNativeActivityTraceController(
   ): boolean => {
     const itemId = sanitizeText(event.itemId || "").trim();
     if (!itemId) return false;
+    agentAnswerStartedAt ||= Date.now();
+    agentMessageItemIds.add(itemId);
+    if (!progressEventIndexes.has(itemId)) {
+      const changed = upsertProgressText(
+        itemId,
+        event.delta,
+        "append",
+        "running",
+        "assistant_message",
+      );
+      if (changed) sync();
+      return changed;
+    }
     getProgressCoalescer(itemId).pushText(event.delta);
     return true;
   };
@@ -4693,11 +4722,20 @@ function createCodexNativeActivityTraceController(
     if (!isCodexNativeAgentMessageItem(event)) return;
     const itemId = sanitizeText(event.id || "").trim();
     if (!itemId) return;
+    agentMessageItemIds.add(itemId);
     flushProgressCoalescer(itemId, "event");
     lastAgentMessageItemId = itemId;
     const completedText = event.details || event.summary || "";
     if (completedText && !progressEventIndexes.has(itemId)) {
-      if (upsertProgressText(itemId, completedText, "replace", "completed")) {
+      if (
+        upsertProgressText(
+          itemId,
+          completedText,
+          "replace",
+          "completed",
+          "assistant_message",
+        )
+      ) {
         sync();
       }
     }
@@ -4727,7 +4765,15 @@ function createCodexNativeActivityTraceController(
     }
     const alreadyFinal = events.some((entry) => entry.payload.type === "final");
     if (!alreadyFinal) {
-      events.push(createEvent({ type: "final", text: finalText }));
+      events.push(
+        createEvent({
+          type: "final",
+          text: finalText,
+          ...(agentAnswerStartedAt
+            ? { answerStartedAt: agentAnswerStartedAt }
+            : {}),
+        }),
+      );
       changed = true;
     }
     if (changed) sync();

--- a/test/agentTraceRender.test.ts
+++ b/test/agentTraceRender.test.ts
@@ -4,6 +4,7 @@ import {
   buildAgentTraceChipDetails,
   buildAgentTraceDisplayItems,
   buildAgentTraceMarkdownForRender,
+  formatAgentActivityDuration,
   getPendingActionButtonLayout,
   renderAgentTrace,
   renderPendingActionCard,
@@ -981,6 +982,178 @@ describe("rendered Markdown code block source controls", function () {
 });
 
 describe("agentTrace render", function () {
+  it("formats compact Codex-style activity durations", function () {
+    assert.equal(formatAgentActivityDuration(250), "1s");
+    assert.equal(formatAgentActivityDuration(259_000), "4m 19s");
+    assert.equal(formatAgentActivityDuration(3_661_000), "1h 1m 1s");
+  });
+
+  it("expands activity while streaming and collapses it when complete", function () {
+    const events: AgentRunEventRecord[] = [
+      {
+        runId: "run-activity-collapse",
+        seq: 1,
+        eventType: "message_delta",
+        payload: { type: "message_delta", text: "Working" },
+        createdAt: 1_000,
+      },
+      {
+        runId: "run-activity-collapse",
+        seq: 2,
+        eventType: "final",
+        payload: { type: "final", text: "Done" },
+        createdAt: 260_000,
+      },
+    ];
+    const message = {
+      role: "assistant" as const,
+      text: "",
+      timestamp: 260_000,
+      runMode: "agent" as const,
+      modelProviderLabel: "Codex",
+      streaming: true,
+    };
+    const workingTrace = renderAgentTrace({
+      doc: fakeDocument,
+      message,
+      events: events.slice(0, 1),
+    }) as unknown as FakeElement;
+    assert.isTrue(
+      (
+        workingTrace.findByClass("llm-agent-activity-details") as
+          | (FakeElement & {
+              open?: boolean;
+            })
+          | null
+      )?.open,
+    );
+    assert.equal(
+      workingTrace.findByClass("llm-agent-activity-summary")?.textContent,
+      "Working…",
+    );
+
+    message.streaming = false;
+    const completedTrace = renderAgentTrace({
+      doc: fakeDocument,
+      message,
+      events,
+    }) as unknown as FakeElement;
+    assert.isFalse(
+      (
+        completedTrace.findByClass("llm-agent-activity-details") as
+          | (FakeElement & {
+              open?: boolean;
+            })
+          | null
+      )?.open,
+    );
+    assert.equal(
+      completedTrace.findByClass("llm-agent-activity-summary")?.textContent,
+      "Worked for 4m 19s",
+    );
+  });
+
+  it("collapses activity when the Codex answer starts", function () {
+    const message = {
+      role: "assistant" as const,
+      text: "",
+      timestamp: 5_000,
+      runMode: "agent" as const,
+      modelProviderLabel: "Codex",
+      streaming: true,
+    };
+    const events: AgentRunEventRecord[] = [
+      {
+        runId: "run-answer-start",
+        seq: 1,
+        eventType: "codex_progress",
+        payload: {
+          type: "codex_progress",
+          itemId: "reasoning-1",
+          text: "Checking context.",
+          status: "running",
+        },
+        createdAt: 1_000,
+      },
+      {
+        runId: "run-answer-start",
+        seq: 2,
+        eventType: "codex_progress",
+        payload: {
+          type: "codex_progress",
+          itemId: "assistant-1",
+          text: "This is the final answer.",
+          status: "running",
+          kind: "assistant_message",
+        },
+        createdAt: 5_000,
+      },
+    ];
+
+    const trace = renderAgentTrace({
+      doc: fakeDocument,
+      message,
+      events,
+    }) as unknown as FakeElement;
+    const details = trace.findByClass("llm-agent-activity-details") as
+      | (FakeElement & {
+          open?: boolean;
+        })
+      | null;
+    assert.isFalse(details?.open);
+    assert.equal(
+      trace.findByClass("llm-agent-activity-summary")?.textContent,
+      "Worked for 4s",
+    );
+    assert.notExists(details?.findByClass("llm-agent-inline-text") || null);
+    assert.include(
+      `${trace.findByClass("llm-agent-inline-text")?.textContent || ""}${
+        trace.findByClass("llm-agent-inline-text")?.innerHTML || ""
+      }`,
+      "This is the final answer",
+    );
+  });
+
+  it("marks native Codex answer events and records their start time", function () {
+    const message = {
+      role: "assistant" as const,
+      text: "",
+      timestamp: 1,
+      runMode: "agent" as const,
+      modelProviderLabel: "Codex",
+      streaming: true,
+    };
+    const controller = createCodexNativeActivityTraceControllerForTests(
+      message,
+      () => undefined,
+    );
+
+    controller.appendAgentMessageDelta({
+      itemId: "assistant-answer",
+      delta: "Answer starts.",
+    });
+    const progress = message.pendingAgentTraceEvents?.find(
+      (entry) => entry.payload.type === "codex_progress",
+    );
+    assert.equal(
+      progress?.payload.type === "codex_progress"
+        ? progress.payload.kind
+        : undefined,
+      "assistant_message",
+    );
+
+    controller.finish("Answer starts.");
+    const finalEvent = message.pendingAgentTraceEvents?.find(
+      (entry) => entry.payload.type === "final",
+    );
+    assert.isAbove(
+      finalEvent?.payload.type === "final"
+        ? Number(finalEvent.payload.answerStartedAt)
+        : 0,
+      0,
+    );
+  });
+
   it("preserves known quote anchors before agent trace DOM decoration", function () {
     const quoteCitation = buildQuoteCitation({
       quoteText: "Interleaved trace quote anchors should not leak.",


### PR DESCRIPTION
## Summary

This PR implements the focused  agent-trace improvement discussed in the previous review #317 .

<img width="957" height="615" alt="compressO-il7WPWCCnNyEZ6ZVW2Uy6" src="https://github.com/user-attachments/assets/3d8bdbb8-10ba-4d2b-b9df-0424310f2136" />

- Keeps agent activity expanded while the task is running.
- Automatically collapses it when the final answer starts.
- Shows the elapsed working time, such as `Worked for 12s`.
- Keeps the final answer outside the collapsed activity section.
- Allows users to manually expand completed activity.

## Validation

- `npm test`
- `npm run lint:check`
- `npm run build`