### PR TITLE
fix(math): reload KaTeX styles across upgrades

### DIFF
--- a/src/modules/contextPanel/index.ts
+++ b/src/modules/contextPanel/index.ts
@@ -126,7 +126,7 @@ import {
 
 export function registerLLMStyles(win: _ZoteroTypes.MainWindow) {
   const doc = win.document;
-  if (doc.getElementById(`${config.addonRef}-styles`)) return;
+  doc.getElementById(`${config.addonRef}-styles`)?.remove();
 
   // Main styles
   const link = doc.createElement("link") as HTMLLinkElement;
@@ -137,6 +137,7 @@ export function registerLLMStyles(win: _ZoteroTypes.MainWindow) {
   doc.documentElement?.appendChild(link);
 
   // KaTeX styles for math rendering
+  doc.getElementById(`${config.addonRef}-katex-styles`)?.remove();
   const katexLink = doc.createElement("link") as HTMLLinkElement;
   katexLink.id = `${config.addonRef}-katex-styles`;
   katexLink.rel = "stylesheet";


### PR DESCRIPTION
## Summary

- Reload the main panel stylesheet when registering window styles.
- Reload the KaTeX stylesheet independently instead of returning when the main stylesheet already exists.
- Fix the originally reported symptom in #238: the radical renders as a dark block with an empty radicand (while copying the formula still shows the correct value), after an add-on update or reload.

Fixes #238.

## Root Cause

The bug lives in stylesheet registration, not in math markup. `registerLLMStyles()` returned as soon as it found the main stylesheet link:

```js
if (doc.getElementById(`${config.addonRef}-styles`)) return;
```

The KaTeX stylesheet is appended after that guard. On an in-place add-on update or reload the main link can survive while the KaTeX stylesheet is missing or points at a stale chrome resource, so the early return leaves KaTeX CSS unregistered.

KaTeX draws `\sqrt` as an inline `<svg><path>` sized at `width:400em` with `preserveAspectRatio="xMinYMin slice"`, and relies on `.katex svg` and `.hide-tail` rules for clipping and positioning. Without that CSS the SVG expands to its intrinsic size (the "dark block") and overdraws the radicand (the "empty" root). This matches the first screenshot in the issue, and reproduces in headless Firefox by rendering the same formula with the KaTeX stylesheet detached.

### Why #238 was not fixed by 35379a81

Commit 35379a81 (`fix the existing math square root rendering issue #238`) only touched the rendered-Markdown sanitizer. It whitelisted the `svg`/`path`/`line` elements under `.katex` so the radical SVG is no longer stripped from the DOM. That addressed a different failure mode — the radical sign disappearing entirely because its elements were removed during sanitization.

The symptom in the original report is one layer lower: the SVG elements are present in the DOM (verified via jsdom), but the stylesheet that lays them out is not applied, so the radical shows as a dark block with an empty radicand. Preserving the SVG does not help when the CSS that draws it is absent, which is why the initially reported rendering persisted after that fix and only reproduced after an update/reload rather than on a fresh install.

## Testing

- Verified the reported factorial-radicand formula with the built XPI in Zotero.
- `npm run typecheck`
- `npm run check:cycles`
- `test/agentTraceRender.test.ts` (108 passing)
- `npm run build`
- XPI archive integrity check
