### PR TITLE
feat: add Atlas Cloud provider preset

### DIFF
--- a/src/utils/providerPresets.ts
+++ b/src/utils/providerPresets.ts
@@ -11,6 +11,7 @@ export type SupportedProviderPresetId =
   | "qwen"
   | "kimi"
   | "mimo"
+  | "atlascloud"
   | "copilot";
 
 export type ProviderPresetId = SupportedProviderPresetId | "customized";
@@ -139,6 +140,7 @@ const QWEN_PATHS = [
 ];
 const KIMI_PATHS = ["/", "/v1", "/v1/chat/completions"];
 const MIMO_PATHS = ["/", "/v1", "/v1/chat/completions"];
+const ATLASCLOUD_PATHS = ["/", "/v1", "/v1/chat/completions"];
 const COPILOT_PATHS = ["/", "/chat/completions", "/models"];
 
 export const PROVIDER_PRESETS: ProviderPreset[] = [
@@ -267,6 +269,17 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     supportedProtocols: ["openai_chat_compat"],
     helperText: "Preset uses Xiaomi MiMo's OpenAI-compatible API base (v1).",
     matches: makeHostAndPathMatcher(["api.xiaomimimo.com"], MIMO_PATHS),
+    supportsEmbeddings: false,
+  },
+  {
+    id: "atlascloud",
+    label: "Atlas Cloud",
+    defaultApiBase: "https://api.atlascloud.ai/v1",
+    defaultProtocol: "openai_chat_compat",
+    supportedProtocols: ["openai_chat_compat"],
+    helperText:
+      "Preset uses Atlas Cloud's OpenAI-compatible chat API base (v1).",
+    matches: makeHostAndPathMatcher(["api.atlascloud.ai"], ATLASCLOUD_PATHS),
     supportsEmbeddings: false,
   },
   {

--- a/test/modelProviders.test.ts
+++ b/test/modelProviders.test.ts
@@ -50,6 +50,10 @@ describe("modelProviders", function () {
       "Xiaomi MiMo",
     );
     assert.equal(
+      deriveProviderLabel("https://api.atlascloud.ai/v1"),
+      "Atlas Cloud",
+    );
+    assert.equal(
       deriveProviderLabel("https://api.minimax.io/anthropic"),
       "MiniMax",
     );
@@ -269,6 +273,34 @@ describe("modelProviders", function () {
 
     assert.lengthOf(entries, 1);
     assert.equal(entries[0].providerProtocol, "openai_chat_compat");
+  });
+
+  it("labels Atlas Cloud runtime entries and keeps chat-compatible routing", function () {
+    const groups: ModelProviderGroup[] = [
+      {
+        id: "provider-1",
+        apiBase: "https://api.atlascloud.ai/v1",
+        apiKey: "sk-atlascloud",
+        authMode: "api_key",
+        providerProtocol: "responses_api",
+        models: [
+          {
+            id: "model-1",
+            model: "qwen/qwen3.5-flash",
+            temperature: 0.3,
+            maxTokens: 4096,
+          },
+        ],
+      },
+    ];
+
+    setModelProviderGroups(groups);
+    const entries = getRuntimeModelEntries();
+
+    assert.lengthOf(entries, 1);
+    assert.equal(entries[0].providerLabel, "Atlas Cloud");
+    assert.equal(entries[0].providerProtocol, "openai_chat_compat");
+    assert.equal(entries[0].model, "qwen/qwen3.5-flash");
   });
 
   it("keeps explicit per-model protocol overrides for known providers", function () {

--- a/test/providerCapabilities.test.ts
+++ b/test/providerCapabilities.test.ts
@@ -118,6 +118,10 @@ describe("provider capabilities", function () {
         protocol: "openai_chat_compat",
       },
       {
+        apiBase: "https://api.atlascloud.ai/v1",
+        protocol: "openai_chat_compat",
+      },
+      {
         apiBase: "https://third-party.example/gemini",
         protocol: "gemini_native",
       },

--- a/test/providerPresets.test.ts
+++ b/test/providerPresets.test.ts
@@ -72,6 +72,14 @@ describe("providerPresets", function () {
       "mimo",
     );
     assert.equal(detectProviderPreset("https://api.xiaomimimo.com/v1"), "mimo");
+    assert.equal(
+      detectProviderPreset("https://api.atlascloud.ai/v1/chat/completions"),
+      "atlascloud",
+    );
+    assert.equal(
+      detectProviderPreset("https://api.atlascloud.ai/v1"),
+      "atlascloud",
+    );
   });
 
   it("falls back to customized for unknown URLs", function () {
@@ -116,6 +124,10 @@ describe("providerPresets", function () {
       getProviderPreset("mimo").defaultApiBase,
       "https://api.xiaomimimo.com/v1",
     );
+    assert.equal(
+      getProviderPreset("atlascloud").defaultApiBase,
+      "https://api.atlascloud.ai/v1",
+    );
   });
 
   it("stores default protocols per preset", function () {
@@ -159,6 +171,13 @@ describe("providerPresets", function () {
     assert.deepEqual(getProviderPreset("mimo").supportedProtocols, [
       "openai_chat_compat",
     ]);
+    assert.equal(
+      getProviderPreset("atlascloud").defaultProtocol,
+      "openai_chat_compat",
+    );
+    assert.deepEqual(getProviderPreset("atlascloud").supportedProtocols, [
+      "openai_chat_compat",
+    ]);
   });
 
   it("offers advanced protocol options beyond preset defaults", function () {
@@ -168,6 +187,11 @@ describe("providerPresets", function () {
       "anthropic_messages",
     ]);
     assert.deepEqual(getProviderPresetProtocolOptions("mimo"), [
+      "openai_chat_compat",
+      "responses_api",
+      "anthropic_messages",
+    ]);
+    assert.deepEqual(getProviderPresetProtocolOptions("atlascloud"), [
       "openai_chat_compat",
       "responses_api",
       "anthropic_messages",
@@ -204,6 +228,12 @@ describe("providerPresets", function () {
   it("does not advertise MiMo as Responses-capable", function () {
     assert.isFalse(
       providerSupportsResponsesEndpoint("https://api.xiaomimimo.com/v1"),
+    );
+  });
+
+  it("does not advertise Atlas Cloud as Responses-capable", function () {
+    assert.isFalse(
+      providerSupportsResponsesEndpoint("https://api.atlascloud.ai/v1"),
     );
   });
 });

--- a/test/providerTransport.test.ts
+++ b/test/providerTransport.test.ts
@@ -87,4 +87,14 @@ describe("providerTransport", function () {
       "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
     );
   });
+
+  it("resolves Atlas Cloud chat-compatible endpoint from the API base", function () {
+    assert.equal(
+      resolveProviderTransportEndpoint({
+        protocol: "openai_chat_compat",
+        apiBase: "https://api.atlascloud.ai/v1",
+      }),
+      "https://api.atlascloud.ai/v1/chat/completions",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Add an Atlas Cloud provider preset using the existing OpenAI-compatible chat protocol path.
- Detect `https://api.atlascloud.ai/v1` and `/v1/chat/completions` as Atlas Cloud in the provider selector.
- Cover provider detection, runtime labeling/protocol routing, transport endpoint resolution, and full-PDF capability behavior with focused tests.

## Validation

- `npm ci --ignore-scripts`
- `npx tsx node_modules/mocha/bin/mocha.js --require ./test/register.cjs test/providerPresets.test.ts test/modelProviders.test.ts test/providerTransport.test.ts test/providerCapabilities.test.ts` (47 passing)
- `npm run typecheck`
- `npx prettier --check src/utils/providerPresets.ts test/providerPresets.test.ts test/modelProviders.test.ts test/providerTransport.test.ts test/providerCapabilities.test.ts`
- `npx eslint src/utils/providerPresets.ts test/providerPresets.test.ts test/modelProviders.test.ts test/providerTransport.test.ts test/providerCapabilities.test.ts`
- `npm run check:cycles`
- `git diff --check`
- Atlas live model catalog check: 437 total models / 375 visible models; confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

Full suite note: `npm run test:unit` reached 2611 passing / 1 pending, then failed 6 existing timing/performance-sensitive tests outside the provider preset area. Rerunning those failed test files passed the PDF locator, path redaction, MinerU, and quote citation cases; the import-cycle Mocha test still hit its 2s timeout, while `npm run check:cycles` passed.
