### PR TITLE
fix(mcp): keep Zotero scope tokens valid across turns of a conversation

### DIFF
--- a/src/agent/mcp/server.ts
+++ b/src/agent/mcp/server.ts
@@ -386,16 +386,19 @@ export function buildZoteroMcpConfigValue(
     scopeToken?: string;
     required?: boolean;
     rawPdfMode?: boolean;
+    enabled?: boolean;
   } = {},
 ): Record<string, unknown> {
   const token = getOrCreateZoteroMcpBearerToken();
   const scopeToken = normalizeText(params.scopeToken, 256);
+  const enabled = params.enabled !== false;
   const enabledToolNames = params.rawPdfMode
     ? getZoteroMcpDirectPdfToolNames()
     : getZoteroMcpAllowedToolNames();
   return {
     url: getZoteroMcpServerUrl(),
-    ...(params.required ? { required: true } : {}),
+    ...(!enabled ? { enabled: false } : {}),
+    ...(enabled && params.required ? { required: true } : {}),
     default_tools_approval_mode: CODEX_MCP_TOOL_APPROVAL_MODE,
     tools: getZoteroMcpToolApprovalOverrides(enabledToolNames),
     http_headers: {
@@ -670,7 +673,8 @@ export function registerScopedZoteroMcpScope(
  * `scopedZoteroMcpScopes` and released when the turn ends. They are not expired
  * on a timer: a token whose conversation is still live in the agent runtime must
  * keep resolving, because the runtime keeps sending the header it captured when
- * the conversation was created. The map is cleared in `unregisterMcpServer()`.
+ * the conversation was created. Endpoint restarts preserve the map; durable
+ * conversation deletion releases its exact entry.
  */
 export function resolveConversationScopeToken(params: {
   profileSignature?: string;
@@ -686,6 +690,25 @@ export function resolveConversationScopeToken(params: {
   const token = generateToken();
   conversationScopeTokens.set(key, token);
   return token;
+}
+
+/**
+ * Releases the stable token after its conversation has been durably deleted.
+ * This is deliberately identity-specific: another Zotero profile can use the
+ * same numeric conversation key and must keep its own live runtime binding.
+ */
+export function releaseConversationScopeToken(params: {
+  profileSignature?: string;
+  conversationKey: number;
+}): void {
+  const conversationKey = Math.floor(Number(params.conversationKey));
+  if (!Number.isFinite(conversationKey) || conversationKey <= 0) return;
+  const key = `${normalizeText(params.profileSignature, 256) || ""} ${conversationKey}`;
+  const token = conversationScopeTokens.get(key);
+  if (!token) return;
+  conversationScopeTokens.delete(key);
+  scopedZoteroMcpScopes.delete(token);
+  clearMcpReadDedupeCacheForScopeToken(token);
 }
 
 export function setActiveZoteroMcpScope(
@@ -1869,7 +1892,6 @@ export async function invokeRegisteredZoteroMcpEndpoint(
  */
 export function unregisterMcpServer(): void {
   scopedZoteroMcpScopes.clear();
-  conversationScopeTokens.clear();
   mcpReadDedupeCache.clear();
   zoteroMcpConfirmationHandlers.clear();
   registeredMcpDeps = null;

--- a/src/agent/mcp/server.ts
+++ b/src/agent/mcp/server.ts
@@ -661,12 +661,26 @@ export function registerScopedZoteroMcpScope(
  * keep reusing it on resume, so a token that only lives for one turn is already
  * stale by the next turn. A conversation-stable token lets every turn re-register
  * its own scope under the same header value.
+ *
+ * Callers pass the identity rather than a pre-joined key so that the turn runner
+ * and the fork path cannot drift on the key format: two spellings of the same
+ * conversation would yield two tokens and bring the stale-header failure back.
+ *
+ * Entries hold only the token. The scope itself is registered per turn in
+ * `scopedZoteroMcpScopes` and released when the turn ends. They are not expired
+ * on a timer: a token whose conversation is still live in the agent runtime must
+ * keep resolving, because the runtime keeps sending the header it captured when
+ * the conversation was created. The map is cleared in `unregisterMcpServer()`.
  */
-export function resolveConversationScopeToken(
-  conversationScopeId: string,
-): string {
-  const key = normalizeText(conversationScopeId, 256);
-  if (!key) return generateToken();
+export function resolveConversationScopeToken(params: {
+  profileSignature?: string;
+  conversationKey: number;
+}): string {
+  const conversationKey = Math.floor(Number(params.conversationKey));
+  if (!Number.isFinite(conversationKey) || conversationKey <= 0) {
+    return generateToken();
+  }
+  const key = `${normalizeText(params.profileSignature, 256) || ""} ${conversationKey}`;
   const existing = conversationScopeTokens.get(key);
   if (existing) return existing;
   const token = generateToken();
@@ -723,7 +737,7 @@ function mcpReadDedupeScopePrefix(scopeToken: string): string {
   return `token:${JSON.stringify(scopeToken)}:`;
 }
 
-export function clearMcpReadDedupeCacheForScopeToken(scopeToken: string): void {
+function clearMcpReadDedupeCacheForScopeToken(scopeToken: string): void {
   const prefix = mcpReadDedupeScopePrefix(scopeToken);
   for (const key of mcpReadDedupeCache.keys()) {
     if (key.startsWith(prefix)) mcpReadDedupeCache.delete(key);

--- a/src/agent/mcp/server.ts
+++ b/src/agent/mcp/server.ts
@@ -179,6 +179,7 @@ const scopedZoteroMcpScopes = new Map<
   string,
   { createdAt: number; expiresAt: number; scope: ZoteroMcpActiveScope }
 >();
+const conversationScopeTokens = new Map<string, string>();
 let activeZoteroMcpScope: ZoteroMcpActiveScope | null = null;
 let registeredMcpDeps: McpServerDeps | null = null;
 const mcpReadDedupeCache = new Map<
@@ -653,6 +654,26 @@ export function registerScopedZoteroMcpScope(
   };
 }
 
+/**
+ * Returns a scope token that stays stable for one conversation.
+ *
+ * Agent runtimes bind the scope header when they create their conversation and
+ * keep reusing it on resume, so a token that only lives for one turn is already
+ * stale by the next turn. A conversation-stable token lets every turn re-register
+ * its own scope under the same header value.
+ */
+export function resolveConversationScopeToken(
+  conversationScopeId: string,
+): string {
+  const key = normalizeText(conversationScopeId, 256);
+  if (!key) return generateToken();
+  const existing = conversationScopeTokens.get(key);
+  if (existing) return existing;
+  const token = generateToken();
+  conversationScopeTokens.set(key, token);
+  return token;
+}
+
 export function setActiveZoteroMcpScope(
   scope: ZoteroMcpActiveScope,
 ): () => void {
@@ -702,7 +723,7 @@ function mcpReadDedupeScopePrefix(scopeToken: string): string {
   return `token:${JSON.stringify(scopeToken)}:`;
 }
 
-function clearMcpReadDedupeCacheForScopeToken(scopeToken: string): void {
+export function clearMcpReadDedupeCacheForScopeToken(scopeToken: string): void {
   const prefix = mcpReadDedupeScopePrefix(scopeToken);
   for (const key of mcpReadDedupeCache.keys()) {
     if (key.startsWith(prefix)) mcpReadDedupeCache.delete(key);
@@ -1195,9 +1216,10 @@ function resolveScopedMcpScope(
   pruneExpiredScopedMcpScopes();
   const entry = scopedZoteroMcpScopes.get(token);
   if (entry) {
-    // A valid token identifies one immutable request scope. The process-wide
-    // active scope may belong to an overlapping turn from the same profile and
-    // must never replace it.
+    // A valid token identifies one conversation, and every turn of that
+    // conversation re-registers its own scope under the token. The process-wide
+    // active scope may belong to an overlapping turn from another conversation
+    // on the same profile and must never replace it.
     return entry.scope;
   }
   throw new Error(
@@ -1833,6 +1855,7 @@ export async function invokeRegisteredZoteroMcpEndpoint(
  */
 export function unregisterMcpServer(): void {
   scopedZoteroMcpScopes.clear();
+  conversationScopeTokens.clear();
   mcpReadDedupeCache.clear();
   zoteroMcpConfirmationHandlers.clear();
   registeredMcpDeps = null;

--- a/src/codexAppServer/mcpSetup.ts
+++ b/src/codexAppServer/mcpSetup.ts
@@ -572,6 +572,7 @@ export function buildCodexZoteroMcpThreadConfig(params: {
   required?: boolean;
   enableShellTool?: boolean;
   rawPdfMode?: boolean;
+  enabled?: boolean;
 }): { serverName: string; config: Record<string, unknown> } {
   const serverName = getZoteroMcpServerName(params.profileSignature);
   return {
@@ -585,6 +586,7 @@ export function buildCodexZoteroMcpThreadConfig(params: {
           scopeToken: params.scopeToken,
           required: params.required,
           rawPdfMode: params.rawPdfMode,
+          enabled: params.enabled,
         }),
       },
     },

--- a/src/codexAppServer/nativeClient.ts
+++ b/src/codexAppServer/nativeClient.ts
@@ -28,6 +28,8 @@ import {
   ZOTERO_MCP_WRITE_TOOL_NAMES,
   getZoteroMcpDirectPdfToolNames,
   registerScopedZoteroMcpScope,
+  resolveConversationScopeToken,
+  clearMcpReadDedupeCacheForScopeToken,
   setActiveZoteroMcpScope,
   type ZoteroMcpActiveScope,
   type ZoteroMcpConfirmationRequest,
@@ -2173,8 +2175,20 @@ export async function runCodexAppServerNativeTurn(params: {
         reasoning: params.reasoning,
         skillContext,
       });
+      // Raw-PDF turns always run on a fresh ephemeral thread, so they keep a
+      // single-turn token. Persistent threads are resumed with the scope header
+      // Codex captured when the thread was created, so they need a token that
+      // stays stable for the whole conversation.
+      const conversationScopeId = currentTurnHasLocalPdfs
+        ? ""
+        : `${profileSignature || ""}:${params.scope.conversationKey}`;
       const scopedMcp = mcpEnabled
-        ? registerScopedZoteroMcpScope(scopedMcpScope)
+        ? registerScopedZoteroMcpScope(
+            scopedMcpScope,
+            conversationScopeId
+              ? { token: resolveConversationScopeToken(conversationScopeId) }
+              : {},
+          )
         : null;
       const mcpThreadConfig = scopedMcp
         ? buildCodexZoteroMcpThreadConfig({
@@ -2646,7 +2660,13 @@ export async function runCodexAppServerNativeTurn(params: {
         return result;
       } finally {
         unregisterGuardianReviews();
-        scopedMcp?.clear();
+        if (scopedMcp) {
+          if (conversationScopeId) {
+            clearMcpReadDedupeCacheForScopeToken(scopedMcp.token);
+          } else {
+            scopedMcp.clear();
+          }
+        }
         clearMcpConfirmationHandler();
         clearMcpScope();
         unregisterApprovalHandlers();

--- a/src/codexAppServer/nativeClient.ts
+++ b/src/codexAppServer/nativeClient.ts
@@ -1914,8 +1914,10 @@ export async function listCodexAppServerModels(
  *
  * `thread/fork` creates the target conversation from the source thread, so
  * without an override it inherits the source conversation's scope header. Resume
- * does not rebind headers, so that header would keep resolving to the source
- * scope for the whole life of the fork.
+ * does not reliably rebind headers on a loaded thread, so that header would keep
+ * resolving to the source scope for the whole life of the fork. The override is
+ * also required while tools are disabled so the fork cannot retain an enabled
+ * source MCP server behind the preference.
  */
 export function buildForkedCodexThreadMcpConfig(
   targetConversationKey?: number,
@@ -1924,7 +1926,7 @@ export function buildForkedCodexThreadMcpConfig(
   if (!Number.isFinite(conversationKey) || conversationKey <= 0) {
     return undefined;
   }
-  if (!isCodexZoteroMcpToolsEnabled()) return undefined;
+  const mcpEnabled = isCodexZoteroMcpToolsEnabled();
   const profileSignature = getCodexProfileSignature();
   return buildCodexZoteroMcpThreadConfig({
     profileSignature,
@@ -1932,7 +1934,8 @@ export function buildForkedCodexThreadMcpConfig(
       profileSignature,
       conversationKey,
     }),
-    required: true,
+    required: mcpEnabled,
+    enabled: mcpEnabled,
   }).config;
 }
 
@@ -1952,10 +1955,41 @@ export async function forkCodexAppServerThread(params: {
   };
   const config = buildForkedCodexThreadMcpConfig(params.targetConversationKey);
   if (config) requestParams.config = config;
-  const result = await proc.sendRequest("thread/fork", requestParams);
-  const threadId = extractCodexAppServerThreadId(result);
-  if (!threadId) throw new Error("Codex app-server did not return a thread ID");
-  return threadId;
+  const targetConversationKey = Math.floor(
+    Number(params.targetConversationKey),
+  );
+  const profileSignature = getCodexProfileSignature();
+  const provisionalMcpScope =
+    config &&
+    isCodexZoteroMcpToolsEnabled() &&
+    Number.isFinite(targetConversationKey) &&
+    targetConversationKey > 0
+      ? registerScopedZoteroMcpScope(
+          {
+            profileSignature,
+            conversationKey: targetConversationKey,
+          },
+          {
+            token: resolveConversationScopeToken({
+              profileSignature,
+              conversationKey: targetConversationKey,
+            }),
+          },
+        )
+      : null;
+  try {
+    // A required MCP server performs tools/list while the fork is being
+    // created. Keep the target token resolvable for that handshake; the first
+    // target turn will register the complete conversation scope under it.
+    const result = await proc.sendRequest("thread/fork", requestParams);
+    const threadId = extractCodexAppServerThreadId(result);
+    if (!threadId) {
+      throw new Error("Codex app-server did not return a thread ID");
+    }
+    return threadId;
+  } finally {
+    provisionalMcpScope?.clear();
+  }
 }
 
 export async function archiveCodexAppServerThread(params: {

--- a/src/codexAppServer/nativeClient.ts
+++ b/src/codexAppServer/nativeClient.ts
@@ -29,7 +29,6 @@ import {
   getZoteroMcpDirectPdfToolNames,
   registerScopedZoteroMcpScope,
   resolveConversationScopeToken,
-  clearMcpReadDedupeCacheForScopeToken,
   setActiveZoteroMcpScope,
   type ZoteroMcpActiveScope,
   type ZoteroMcpConfirmationRequest,
@@ -1910,8 +1909,36 @@ export async function listCodexAppServerModels(
   return proc.sendRequest("model/list", requestParams);
 }
 
+/**
+ * Builds the MCP thread config a forked conversation must be created with.
+ *
+ * `thread/fork` creates the target conversation from the source thread, so
+ * without an override it inherits the source conversation's scope header. Resume
+ * does not rebind headers, so that header would keep resolving to the source
+ * scope for the whole life of the fork.
+ */
+export function buildForkedCodexThreadMcpConfig(
+  targetConversationKey?: number,
+): Record<string, unknown> | undefined {
+  const conversationKey = Math.floor(Number(targetConversationKey));
+  if (!Number.isFinite(conversationKey) || conversationKey <= 0) {
+    return undefined;
+  }
+  if (!isCodexZoteroMcpToolsEnabled()) return undefined;
+  const profileSignature = getCodexProfileSignature();
+  return buildCodexZoteroMcpThreadConfig({
+    profileSignature,
+    scopeToken: resolveConversationScopeToken({
+      profileSignature,
+      conversationKey,
+    }),
+    required: true,
+  }).config;
+}
+
 export async function forkCodexAppServerThread(params: {
   threadId: string;
+  targetConversationKey?: number;
   codexPath?: string;
   processKey?: string;
 }): Promise<string> {
@@ -1920,9 +1947,12 @@ export async function forkCodexAppServerThread(params: {
     params.processKey || CODEX_APP_SERVER_NATIVE_PROCESS_KEY,
     { codexPath },
   );
-  const result = await proc.sendRequest("thread/fork", {
+  const requestParams: Record<string, unknown> = {
     threadId: params.threadId,
-  });
+  };
+  const config = buildForkedCodexThreadMcpConfig(params.targetConversationKey);
+  if (config) requestParams.config = config;
+  const result = await proc.sendRequest("thread/fork", requestParams);
   const threadId = extractCodexAppServerThreadId(result);
   if (!threadId) throw new Error("Codex app-server did not return a thread ID");
   return threadId;
@@ -2179,15 +2209,16 @@ export async function runCodexAppServerNativeTurn(params: {
       // single-turn token. Persistent threads are resumed with the scope header
       // Codex captured when the thread was created, so they need a token that
       // stays stable for the whole conversation.
-      const conversationScopeId = currentTurnHasLocalPdfs
+      const persistentScopeToken = currentTurnHasLocalPdfs
         ? ""
-        : `${profileSignature || ""}:${params.scope.conversationKey}`;
+        : resolveConversationScopeToken({
+            profileSignature,
+            conversationKey: params.scope.conversationKey,
+          });
       const scopedMcp = mcpEnabled
         ? registerScopedZoteroMcpScope(
             scopedMcpScope,
-            conversationScopeId
-              ? { token: resolveConversationScopeToken(conversationScopeId) }
-              : {},
+            persistentScopeToken ? { token: persistentScopeToken } : {},
           )
         : null;
       const mcpThreadConfig = scopedMcp
@@ -2660,13 +2691,10 @@ export async function runCodexAppServerNativeTurn(params: {
         return result;
       } finally {
         unregisterGuardianReviews();
-        if (scopedMcp) {
-          if (conversationScopeId) {
-            clearMcpReadDedupeCacheForScopeToken(scopedMcp.token);
-          } else {
-            scopedMcp.clear();
-          }
-        }
+        // The scope registration only lives for the turn. The next turn resolves
+        // the same conversation-stable token and registers its own scope under
+        // it, so the header Codex captured at thread creation stays valid.
+        scopedMcp?.clear();
         clearMcpConfirmationHandler();
         clearMcpScope();
         unregisterApprovalHandlers();

--- a/src/core/conversations/repository.ts
+++ b/src/core/conversations/repository.ts
@@ -76,6 +76,8 @@ import {
   type StoredChatMessage,
 } from "../../utils/chatStore";
 import { codexAppServerForkService } from "../../codexAppServer/forkService";
+import { getCodexProfileSignature } from "../../codexAppServer/constants";
+import { releaseConversationScopeToken } from "../../agent/mcp/server";
 import {
   deleteConversationForkLink,
   recordConversationForkLink,
@@ -1023,6 +1025,10 @@ export const conversationRepository = {
     }
     if (target.system === "codex") {
       await deleteCodexConversation(conversationKey);
+      releaseConversationScopeToken({
+        profileSignature: getCodexProfileSignature(),
+        conversationKey,
+      });
       await cleanupForkLink();
       return;
     }
@@ -1049,6 +1055,10 @@ export const conversationRepository = {
     }
     if (target.system === "codex") {
       await deleteCodexConversationLocalRows(conversationKey);
+      releaseConversationScopeToken({
+        profileSignature: getCodexProfileSignature(),
+        conversationKey,
+      });
       return;
     }
     await deleteUpstreamConversationLocalRows(conversationKey, target.kind);

--- a/src/core/conversations/repository.ts
+++ b/src/core/conversations/repository.ts
@@ -674,18 +674,11 @@ export const conversationRepository = {
     const sourceProviderSessionId =
       normalizeTitle(sourceEntry.providerSessionId) || "";
 
-    let forkedCodexThreadId: string | null = null;
     if (params.system === "codex") {
       const latestCodexForkableAssistantTimestamp =
         await getLatestCodexForkableAssistantTimestamp(sourceConversationKey);
       if (latestCodexForkableAssistantTimestamp !== throughAssistantTimestamp) {
         return null;
-      }
-      if (sourceProviderSessionId) {
-        forkedCodexThreadId = await codexAppServerForkService.forkThread({
-          threadId: sourceProviderSessionId,
-        });
-        if (!forkedCodexThreadId) return null;
       }
     }
 
@@ -695,15 +688,38 @@ export const conversationRepository = {
       libraryID,
       paperItemID,
     });
-    if (!entry) {
-      if (forkedCodexThreadId) {
-        await codexAppServerForkService
-          .archiveThread({ threadId: forkedCodexThreadId })
+    if (!entry) return null;
+
+    // The catalog entry is created first so the fork can be told which
+    // conversation it belongs to. Codex binds the Zotero scope header when it
+    // creates the target conversation, and resume never rebinds it, so a fork
+    // that inherits the source header would stay bound to the source scope.
+    let forkedCodexThreadId: string | null = null;
+    if (params.system === "codex" && sourceProviderSessionId) {
+      const discardForkEntry = async () => {
+        await conversationRepository
+          .deleteCatalogEntry({
+            system: "codex",
+            kind: entry.kind,
+            conversationKey: entry.conversationKey,
+          })
           .catch(() => {});
+      };
+      try {
+        forkedCodexThreadId = await codexAppServerForkService.forkThread({
+          threadId: sourceProviderSessionId,
+          targetConversationKey: entry.conversationKey,
+        });
+      } catch (err) {
+        await discardForkEntry();
+        throw err;
       }
-      return null;
+      if (!forkedCodexThreadId) {
+        await discardForkEntry();
+        return null;
+      }
     }
-    if (entry && params.system === "codex" && forkedCodexThreadId) {
+    if (params.system === "codex" && forkedCodexThreadId) {
       const persistedProviderSession = await upsertCodexConversationSummary({
         conversationKey: entry.conversationKey,
         libraryID,

--- a/test/codexAppServerNativeClient.test.ts
+++ b/test/codexAppServerNativeClient.test.ts
@@ -29,9 +29,13 @@ import {
   destroyCachedCodexAppServerProcess,
 } from "../src/utils/codexAppServerProcess";
 import {
+  invokeRegisteredZoteroMcpEndpoint,
+  registerMcpServer,
   resolveConversationScopeToken,
+  unregisterMcpServer,
   ZOTERO_MCP_SCOPE_HEADER,
 } from "../src/agent/mcp/server";
+import { AgentToolRegistry } from "../src/agent/tools/registry";
 import { getCodexProfileSignature } from "../src/codexAppServer/constants";
 import { getUserSkillsRuntimeRootDir } from "../src/agent/skills/userSkills";
 import {
@@ -1092,33 +1096,67 @@ describe("Codex app-server native client", function () {
     const processKey = "native-fork-scope-header";
     const originalSpawn = CodexAppServerProcess.spawn;
     const originalZotero = (globalThis as { Zotero?: unknown }).Zotero;
+    const prefStore = new Map<string, unknown>();
     const writes: string[] = [];
     const proc = CodexAppServerProcess.forTest({
       stdin: {
         write: (chunk: string) => {
           writes.push(chunk);
-          const request = JSON.parse(chunk) as { id: number; method: string };
+          const request = JSON.parse(chunk) as {
+            id: number;
+            method: string;
+            params?: Record<string, any>;
+          };
           if (request.method !== "thread/fork") return;
-          setTimeout(() => {
-            (
+          void (async () => {
+            const servers = request.params?.config?.mcp_servers as Record<
+              string,
+              { http_headers?: Record<string, string> }
+            >;
+            const serverConfig = Object.values(servers || {})[0];
+            const response = await invokeRegisteredZoteroMcpEndpoint({
+              method: "POST",
+              data: {
+                jsonrpc: "2.0",
+                id: 1,
+                method: "tools/list",
+                params: {},
+              },
+              headers: serverConfig?.http_headers,
+            });
+            const responseBody = JSON.parse(response?.[2] || "{}");
+            const handleMessage = (
               proc as unknown as {
                 handleMessage: (msg: Record<string, unknown>) => void;
               }
-            ).handleMessage({
+            ).handleMessage.bind(proc);
+            if (responseBody.error) {
+              handleMessage({ id: request.id, error: responseBody.error });
+              return;
+            }
+            handleMessage({
               id: request.id,
               result: { thread: { id: "thread-forked" } },
             });
-          }, 0);
+          })();
         },
       },
       kill: () => {},
     });
     CodexAppServerProcess.spawn = async () => proc;
     (globalThis as { Zotero?: unknown }).Zotero = {
-      Prefs: { get: () => undefined },
+      Prefs: {
+        get: (key: string) => prefStore.get(key),
+        set: (key: string, value: unknown) => prefStore.set(key, value),
+      },
       Profile: { dir: "/tmp/lfz-fork-scope-profile" },
       DataDirectory: { dir: "/tmp/lfz-fork-scope-data" },
+      Server: { Endpoints: {} },
     };
+    registerMcpServer({
+      toolRegistry: new AgentToolRegistry(),
+      zoteroGateway: {} as never,
+    });
 
     try {
       const threadId = await forkCodexAppServerThread({
@@ -1163,6 +1201,93 @@ describe("Codex app-server native client", function () {
         }),
       );
     } finally {
+      unregisterMcpServer();
+      CodexAppServerProcess.spawn = originalSpawn;
+      destroyCachedCodexAppServerProcess(processKey, proc, {
+        codexPath: "codex",
+      });
+      (globalThis as { Zotero?: unknown }).Zotero = originalZotero;
+    }
+  });
+
+  it("overrides the inherited MCP server while tools are disabled", async function () {
+    const processKey = "native-fork-disabled-scope-header";
+    const originalSpawn = CodexAppServerProcess.spawn;
+    const originalZotero = (globalThis as { Zotero?: unknown }).Zotero;
+    const prefStore = new Map<string, unknown>();
+    const writes: string[] = [];
+    const proc = CodexAppServerProcess.forTest({
+      stdin: {
+        write: (chunk: string) => {
+          writes.push(chunk);
+          const request = JSON.parse(chunk) as { id: number; method: string };
+          if (request.method !== "thread/fork") return;
+          setTimeout(() => {
+            (
+              proc as unknown as {
+                handleMessage: (msg: Record<string, unknown>) => void;
+              }
+            ).handleMessage({
+              id: request.id,
+              result: { thread: { id: "thread-forked-disabled" } },
+            });
+          }, 0);
+        },
+      },
+      kill: () => {},
+    });
+    CodexAppServerProcess.spawn = async () => proc;
+    (globalThis as { Zotero?: unknown }).Zotero = {
+      Prefs: {
+        get: (key: string) =>
+          key.endsWith(".codexAppServerZoteroMcpToolsEnabled")
+            ? false
+            : prefStore.get(key),
+        set: (key: string, value: unknown) => prefStore.set(key, value),
+      },
+      Profile: { dir: "/tmp/lfz-fork-disabled-scope-profile" },
+      DataDirectory: { dir: "/tmp/lfz-fork-disabled-scope-data" },
+      Server: { Endpoints: {} },
+    };
+
+    try {
+      const threadId = await forkCodexAppServerThread({
+        threadId: "thread-source",
+        targetConversationKey: 6_000_000_313,
+        processKey,
+        codexPath: "codex",
+      });
+      assert.equal(threadId, "thread-forked-disabled");
+
+      const forkRequest = writes
+        .map(
+          (chunk) =>
+            JSON.parse(chunk) as {
+              method: string;
+              params: Record<string, any>;
+            },
+        )
+        .find((entry) => entry.method === "thread/fork");
+      const servers = forkRequest?.params.config?.mcp_servers as Record<
+        string,
+        {
+          enabled?: boolean;
+          required?: boolean;
+          http_headers?: Record<string, string>;
+        }
+      >;
+      const serverConfig = Object.values(servers || {})[0];
+      assert.equal(serverConfig?.enabled, false);
+      assert.notProperty(serverConfig || {}, "required");
+      assert.equal(
+        serverConfig?.http_headers?.[ZOTERO_MCP_SCOPE_HEADER],
+        resolveConversationScopeToken({
+          profileSignature: getCodexProfileSignature(),
+          conversationKey: 6_000_000_313,
+        }),
+      );
+    } finally {
+      unregisterMcpServer();
       CodexAppServerProcess.spawn = originalSpawn;
       destroyCachedCodexAppServerProcess(processKey, proc, {
         codexPath: "codex",

--- a/test/codexAppServerNativeClient.test.ts
+++ b/test/codexAppServerNativeClient.test.ts
@@ -10,6 +10,7 @@ import {
   buildZoteroEnvironmentManifest,
   compactCodexAppServerConversation,
   compactCodexAppServerThread,
+  forkCodexAppServerThread,
   isDeniedTrustedZoteroMcpGuardianReviewForTests,
   listCodexAppServerModels,
   NO_CODEX_APP_SERVER_THREAD_TO_COMPACT_MESSAGE,
@@ -27,6 +28,11 @@ import {
   CodexAppServerProcess,
   destroyCachedCodexAppServerProcess,
 } from "../src/utils/codexAppServerProcess";
+import {
+  resolveConversationScopeToken,
+  ZOTERO_MCP_SCOPE_HEADER,
+} from "../src/agent/mcp/server";
+import { getCodexProfileSignature } from "../src/codexAppServer/constants";
 import { getUserSkillsRuntimeRootDir } from "../src/agent/skills/userSkills";
 import {
   BUILTIN_SKILL_FILES,
@@ -1080,6 +1086,89 @@ describe("Codex app-server native client", function () {
       cursor: "cursor-1",
       limit: 50,
     });
+  });
+
+  it("forks a thread with the target conversation's scope header, not the source's", async function () {
+    const processKey = "native-fork-scope-header";
+    const originalSpawn = CodexAppServerProcess.spawn;
+    const originalZotero = (globalThis as { Zotero?: unknown }).Zotero;
+    const writes: string[] = [];
+    const proc = CodexAppServerProcess.forTest({
+      stdin: {
+        write: (chunk: string) => {
+          writes.push(chunk);
+          const request = JSON.parse(chunk) as { id: number; method: string };
+          if (request.method !== "thread/fork") return;
+          setTimeout(() => {
+            (
+              proc as unknown as {
+                handleMessage: (msg: Record<string, unknown>) => void;
+              }
+            ).handleMessage({
+              id: request.id,
+              result: { thread: { id: "thread-forked" } },
+            });
+          }, 0);
+        },
+      },
+      kill: () => {},
+    });
+    CodexAppServerProcess.spawn = async () => proc;
+    (globalThis as { Zotero?: unknown }).Zotero = {
+      Prefs: { get: () => undefined },
+      Profile: { dir: "/tmp/lfz-fork-scope-profile" },
+      DataDirectory: { dir: "/tmp/lfz-fork-scope-data" },
+    };
+
+    try {
+      const threadId = await forkCodexAppServerThread({
+        threadId: "thread-source",
+        targetConversationKey: 6_000_000_311,
+        processKey,
+        codexPath: "codex",
+      });
+      assert.equal(threadId, "thread-forked");
+
+      const forkRequest = writes
+        .map(
+          (chunk) =>
+            JSON.parse(chunk) as {
+              method: string;
+              params: Record<string, any>;
+            },
+        )
+        .find((entry) => entry.method === "thread/fork");
+      assert.equal(forkRequest?.params.threadId, "thread-source");
+
+      const servers = forkRequest?.params.config?.mcp_servers as Record<
+        string,
+        { http_headers?: Record<string, string> }
+      >;
+      const serverConfig = Object.values(servers || {})[0];
+      const sentScopeToken =
+        serverConfig?.http_headers?.[ZOTERO_MCP_SCOPE_HEADER];
+      const profileSignature = getCodexProfileSignature();
+      assert.equal(
+        sentScopeToken,
+        resolveConversationScopeToken({
+          profileSignature,
+          conversationKey: 6_000_000_311,
+        }),
+      );
+      assert.notEqual(
+        sentScopeToken,
+        resolveConversationScopeToken({
+          profileSignature,
+          conversationKey: 6_000_000_310,
+        }),
+      );
+    } finally {
+      CodexAppServerProcess.spawn = originalSpawn;
+      destroyCachedCodexAppServerProcess(processKey, proc, {
+        codexPath: "codex",
+      });
+      (globalThis as { Zotero?: unknown }).Zotero = originalZotero;
+    }
   });
 
   it("auto-approves trusted Zotero MCP approval prompts except self-confirmation", function () {

--- a/test/codexZoteroMcpServer.test.ts
+++ b/test/codexZoteroMcpServer.test.ts
@@ -2490,24 +2490,35 @@ describe("Zotero MCP server", function () {
           kind: "global",
           activeItemId,
         },
-        { token: resolveConversationScopeToken("profile-conv:501") },
+        {
+          token: resolveConversationScopeToken({
+            profileSignature: "profile-conv",
+            conversationKey: 501,
+          }),
+        },
       );
     const firstTurn = registerTurn(10);
+    // Turn teardown releases the scope; only the token stays registered.
+    firstTurn.clear();
     const secondTurn = registerTurn(20);
-    assert.equal(secondTurn.token, firstTurn.token);
+    try {
+      assert.equal(secondTurn.token, firstTurn.token);
 
-    const response = await invokeMcpEndpoint({
-      token: getOrCreateZoteroMcpBearerToken(),
-      headers: { [ZOTERO_MCP_SCOPE_HEADER]: firstTurn.token },
-      body: {
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/call",
-        params: { name: "library_read", arguments: {} },
-      },
-    });
-    assert.isUndefined(JSON.parse(response[2]).error);
-    assert.equal(seenActiveItemId, 20);
+      const response = await invokeMcpEndpoint({
+        token: getOrCreateZoteroMcpBearerToken(),
+        headers: { [ZOTERO_MCP_SCOPE_HEADER]: firstTurn.token },
+        body: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "library_read", arguments: {} },
+        },
+      });
+      assert.isUndefined(JSON.parse(response[2]).error);
+      assert.equal(seenActiveItemId, 20);
+    } finally {
+      secondTurn.clear();
+    }
   });
 
   it("rejects stale cached MCP write headers instead of rebinding them", async function () {

--- a/test/codexZoteroMcpServer.test.ts
+++ b/test/codexZoteroMcpServer.test.ts
@@ -6,6 +6,7 @@ import {
   getZoteroMcpServerUrl,
   registerScopedZoteroMcpScope,
   registerMcpServer,
+  releaseConversationScopeToken,
   resolveConversationScopeToken,
   setActiveZoteroMcpScope,
   unregisterMcpServer,
@@ -2519,6 +2520,82 @@ describe("Zotero MCP server", function () {
     } finally {
       secondTurn.clear();
     }
+  });
+
+  it("keeps a conversation scope token stable across MCP endpoint restarts", function () {
+    const firstToken = resolveConversationScopeToken({
+      profileSignature: "profile-restart",
+      conversationKey: 503,
+    });
+
+    unregisterMcpServer();
+
+    assert.equal(
+      resolveConversationScopeToken({
+        profileSignature: "profile-restart",
+        conversationKey: 503,
+      }),
+      firstToken,
+    );
+  });
+
+  it("releases only the deleted conversation's stable scope token", async function () {
+    registerMcpServer({
+      toolRegistry: new AgentToolRegistry(),
+      zoteroGateway: {} as never,
+    });
+    const firstToken = resolveConversationScopeToken({
+      profileSignature: "profile-cleanup-a",
+      conversationKey: 502,
+    });
+    const otherProfileToken = resolveConversationScopeToken({
+      profileSignature: "profile-cleanup-b",
+      conversationKey: 502,
+    });
+    const activeScope = registerScopedZoteroMcpScope(
+      {
+        profileSignature: "profile-cleanup-a",
+        conversationKey: 502,
+        libraryID: 1,
+        kind: "global",
+      },
+      { token: firstToken },
+    );
+
+    releaseConversationScopeToken({
+      profileSignature: "profile-cleanup-a",
+      conversationKey: 502,
+    });
+
+    assert.notEqual(
+      resolveConversationScopeToken({
+        profileSignature: "profile-cleanup-a",
+        conversationKey: 502,
+      }),
+      firstToken,
+    );
+    assert.equal(
+      resolveConversationScopeToken({
+        profileSignature: "profile-cleanup-b",
+        conversationKey: 502,
+      }),
+      otherProfileToken,
+    );
+    const staleResponse = await invokeMcpEndpoint({
+      token: getOrCreateZoteroMcpBearerToken(),
+      headers: { [ZOTERO_MCP_SCOPE_HEADER]: firstToken },
+      body: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      },
+    });
+    assert.match(
+      JSON.parse(staleResponse[2]).error.message,
+      /scope token is invalid or expired/i,
+    );
+    activeScope.clear();
   });
 
   it("rejects stale cached MCP write headers instead of rebinding them", async function () {

--- a/test/codexZoteroMcpServer.test.ts
+++ b/test/codexZoteroMcpServer.test.ts
@@ -6,6 +6,7 @@ import {
   getZoteroMcpServerUrl,
   registerScopedZoteroMcpScope,
   registerMcpServer,
+  resolveConversationScopeToken,
   setActiveZoteroMcpScope,
   unregisterMcpServer,
   ZOTERO_MCP_ENDPOINT_PATH,
@@ -2460,6 +2461,53 @@ describe("Zotero MCP server", function () {
       clearHandler();
       scoped.clear();
     }
+  });
+
+  it("keeps a conversation scope token usable across turns and rebinds it to the newest turn", async function () {
+    let seenActiveItemId: number | undefined;
+    const registry = new AgentToolRegistry();
+    registry.register({
+      spec: {
+        name: "library_read",
+        description: "Read an item",
+        inputSchema: { type: "object", additionalProperties: true },
+        mutability: "read",
+        requiresConfirmation: false,
+      },
+      validate: (args) => ({ ok: true, value: args ?? {} }),
+      execute: async (_input, context: AgentToolContext) => {
+        seenActiveItemId = context.request.activeItemId;
+        return { activeItemId: context.request.activeItemId };
+      },
+    });
+    registerMcpServer({ toolRegistry: registry, zoteroGateway: {} as never });
+    const registerTurn = (activeItemId: number) =>
+      registerScopedZoteroMcpScope(
+        {
+          profileSignature: "profile-conv",
+          conversationKey: 501,
+          libraryID: 1,
+          kind: "global",
+          activeItemId,
+        },
+        { token: resolveConversationScopeToken("profile-conv:501") },
+      );
+    const firstTurn = registerTurn(10);
+    const secondTurn = registerTurn(20);
+    assert.equal(secondTurn.token, firstTurn.token);
+
+    const response = await invokeMcpEndpoint({
+      token: getOrCreateZoteroMcpBearerToken(),
+      headers: { [ZOTERO_MCP_SCOPE_HEADER]: firstTurn.token },
+      body: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "library_read", arguments: {} },
+      },
+    });
+    assert.isUndefined(JSON.parse(response[2]).error);
+    assert.equal(seenActiveItemId, 20);
   });
 
   it("rejects stale cached MCP write headers instead of rebinding them", async function () {

--- a/test/conversationRepository.test.ts
+++ b/test/conversationRepository.test.ts
@@ -672,6 +672,7 @@ describe("conversationRepository", function () {
     const originalGetCatalogEntry = conversationRepository.getCatalogEntry;
     const originalSetCatalogTitle = conversationRepository.setCatalogTitle;
     const forkCalls: string[] = [];
+    const forkTargetConversationKeys: (number | undefined)[] = [];
     const archiveCalls: string[] = [];
     const insertedMessages: unknown[][] = [];
     const registryRows = new Map<number, Record<string, unknown>>();
@@ -680,6 +681,7 @@ describe("conversationRepository", function () {
 
     codexAppServerForkService.forkThread = async (params) => {
       forkCalls.push(params.threadId);
+      forkTargetConversationKeys.push(params.targetConversationKey);
       return "thread-forked";
     };
     codexAppServerForkService.archiveThread = async (params) => {
@@ -818,6 +820,7 @@ describe("conversationRepository", function () {
       assert.equal(result?.entry.conversationKey, targetConversationKey);
       assert.equal(result?.copiedMessageCount, 2);
       assert.deepEqual(forkCalls, ["thread-source"]);
+      assert.deepEqual(forkTargetConversationKeys, [targetConversationKey]);
       assert.deepEqual(archiveCalls, []);
       assert.equal(persistedProviderSessionId, "thread-forked");
       assert.lengthOf(insertedMessages, 2);


### PR DESCRIPTION
## Summary

- Give persistent Codex threads a scope token that stays stable for the whole conversation, and re-register the current turn's scope under that token on every turn.
- Stop deleting the token when a turn ends; turn teardown now only drops the read dedupe cache for it.
- Keep single-turn tokens for raw-PDF turns, which always run on a fresh ephemeral thread.
- Add a regression test asserting that a header captured during the first turn resolves to the second turn's scope.

## Symptoms

Only the first turn of a Codex thread can call Zotero MCP tools. Every later turn fails with:

```
Zotero MCP scope token is invalid or expired.
Start a new Codex turn from Zotero so tools bind to the current profile and library.
```

What this looks like in practice:

- A new chat works normally. Some turns later, every Zotero MCP call fails, `paper_read` and `file_io` alike.
- Turns that need no tools are unaffected, so the failure surfaces only when the model next reaches for the library. It reads as a connection that worked and then expired partway through a chat, rather than as a per-turn failure.
- Once blocked, the model answers without library access. It may fall back to a public copy of the paper and report the Zotero connection as expired, which is misleading: the account, the library and the attachment are all fine.
- Passing explicit `libraryID` / `activeItemId` arguments does not help. The call is rejected before scope resolution ever reads them.
- It can appear to recover on its own after a long idle gap or a Zotero restart. In that case the app-server has rebuilt the conversation from the config it was handed, so it picks up that turn's token and succeeds for exactly one turn before failing again.

Codex thread transcripts show the pattern directly. In one thread the first turn completed 20 consecutive `paper_read` calls and the following turn failed on both of its calls. In another, the first turn made four successful calls and a later turn failed on every attempt.

## Root cause

`runCodexAppServerNativeTurn()` registered a fresh random scope token for each turn and deleted it in the turn's `finally` block. The token reaches Codex inside the thread config, as the `X-LLM-For-Zotero-Scope` header built by `buildZoteroMcpConfigValue()`.

Codex binds MCP server headers when it creates the conversation behind a thread. Passing a new config on `thread/resume` does not rebind the headers of a conversation that is still live in the app-server process, so every turn after the first sends the header that was captured at `thread/start`. By then the plugin has already deleted that token.

`resolveScopedMcpScope()` rejects an unknown token outright:

```ts
const entry = scopedZoteroMcpScopes.get(token);
if (entry) return entry.scope;
throw new Error(
  "Zotero MCP scope token is invalid or expired. ...",
);
```

The fallback to the process-wide `activeZoteroMcpScope` applies only when the header is absent, so a stale header is strictly worse than no header at all. That fallback is deliberately narrow, because the active scope may belong to an overlapping turn from another conversation on the same profile, and it must not silently replace a scoped one.

The token lifetime was therefore the defect: it was scoped to a turn, while the transport that carries it is scoped to a thread.

## Fix

Persistent threads now derive their token from the profile signature and conversation key, so it stays stable across turns of one conversation. Each turn re-registers its own scope under that token, which also refreshes the TTL. A header captured at thread creation consequently always resolves to the current turn's scope. Tokens remain unguessable; only their lifetime changed.

Turn teardown clears the read dedupe cache for the token instead of deleting the entry. Without that step a follow-up question within the 2 minute dedupe window would be answered from cache and marked `duplicate`.

Raw-PDF turns keep the previous single-turn token. They always start a fresh ephemeral thread, so their header is never stale, and the exact-token requirement that guards raw PDF access stays as strict as before.

No persistence is needed. The Codex app-server runs as a `Subprocess` of Zotero, so it cannot outlive the plugin, and a header from a previous Zotero session cannot reach the endpoint. The in-memory token map is cleared in `unregisterMcpServer()` alongside the existing scope and dedupe maps.

Isolation between conversations is unchanged: a token still identifies exactly one conversation, distinct conversations still receive distinct tokens, and turns are serialized per app-server process.

The Claude Code bridge is untouched. It passes a fresh `mcpServers` config on every query, so its headers are never stale.

## Testing

- New regression test `keeps a conversation scope token usable across turns and rebinds it to the newest turn`: a token registered in the first turn stays valid after teardown, and a call carrying that header resolves to the second turn's scope.
- The existing test `rejects stale cached MCP write headers instead of rebinding them` still passes, so an explicitly cleared token is still refused.
- `test/codexZoteroMcpServer.test.ts` (33 passing)
- `npm run test:unit` (2614 passing, 1 pending). The single failure, `activates only an explicitly selected skill on a PDF turn`, is pre-existing on `main` and unrelated to this change.
- `npm run typecheck`
- `npm run check:cycles`
- `npm run lint:check` on the touched files
- `npm run build`
