### PR TITLE
docs: add optional live web search to Codex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,18 @@ planned for future deprecation after app-server validation.
 7. In the chat header, click **Codex** to switch into the Codex conversation
    system.
 
+#### Optional: add live web search
+
+The Zotero MCP tools focus on your library and scholarly discovery. To also use
+live general web search and URL fetching in Codex, add Parallel Search MCP:
+
+```bash
+codex mcp add parallel-search --url https://search.parallel.ai/mcp
+```
+
+The remote endpoint is free and requires no account or API key. It runs
+alongside the existing Zotero library and scholarly-search tools.
+
 `Codex App Server` and `Claude Code` are mutually exclusive runtime modes in the
 Agent tab. Disable one before enabling the other.
 


### PR DESCRIPTION
Codex App Server users already have llm-for-zotero's library and scholarly discovery tools, but the setup guide did not show how to add general web search. This documents an optional companion MCP server without changing the plugin's behavior or defaults.

## What changed

- Added the one-command Codex setup for Parallel Search MCP.
- Clarified that the remote endpoint requires no account or API key and runs alongside the existing Zotero and scholarly-search tools.

## Validation

- `git diff --check`
- Verified the Streamable HTTP command shape with `codex mcp add --help`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.