### PR TITLE
Add Todo task tracking for Agent mode

### DIFF
--- a/addon/content/zoteroPane.css
+++ b/addon/content/zoteroPane.css
@@ -4878,6 +4878,80 @@ label.llm-search-results-item:hover {
   line-height: 1.6;
 }
 
+/* Compact session Todo cards: title, ordinal, and an accessible status symbol. */
+.llm-agent-todo-list .llm-agent-hitl-header {
+  text-transform: uppercase;
+}
+
+.llm-agent-todo-list .llm-search-results-list {
+  gap: 4px;
+}
+
+.llm-agent-todo-list .llm-search-results-item {
+  padding: 7px 8px;
+  border-left: 3px solid var(--fill-quaternary);
+}
+
+.llm-agent-todo-list .llm-search-results-title-row {
+  align-items: center;
+}
+
+.llm-agent-todo-list .llm-search-results-title {
+  font-size: var(--llm-fs-10);
+  font-weight: 600;
+}
+
+.llm-agent-todo-status {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-left: auto;
+  border-radius: 50%;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--fill-tertiary);
+  background: color-mix(
+    in srgb,
+    var(--fill-tertiary) 12%,
+    var(--material-background)
+  );
+}
+
+.llm-agent-todo-item--pending {
+  border-left-color: var(--fill-quaternary) !important;
+}
+
+.llm-agent-todo-status--pending {
+  color: var(--fill-tertiary);
+}
+
+.llm-agent-todo-item--in_progress {
+  border-left-color: var(--color-accent) !important;
+}
+
+.llm-agent-todo-status--in_progress {
+  color: var(--color-accent);
+  background: color-mix(
+    in srgb,
+    var(--color-accent) 13%,
+    var(--material-background)
+  );
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent);
+}
+
+.llm-agent-todo-item--completed {
+  border-left-color: #2f9e62 !important;
+}
+
+.llm-agent-todo-status--completed {
+  color: #2f9e62;
+  background: color-mix(in srgb, #2f9e62 13%, var(--material-background));
+}
+
 .llm-at-row {
   display: flex;
   align-items: flex-start;

--- a/src/agent/model/messageBuilder.ts
+++ b/src/agent/model/messageBuilder.ts
@@ -9,6 +9,7 @@ import { buildAgentMemoryBlock } from "../store/conversationMemory";
 import { getAllSkills } from "../skills";
 import type { AgentSkill } from "../skills";
 import { classifyWriteNoteDestination } from "../writeNoteDestination";
+import { getAgentTodos } from "../tools/todoWrite";
 
 import { resolveProviderCapabilities } from "../../providers";
 import type { ProviderCapabilities } from "../../providers";
@@ -522,6 +523,19 @@ function buildRuntimePlatformSection(): string {
   return buildRuntimePlatformGuidanceText();
 }
 
+function buildTodoProgressInstruction(request: AgentRuntimeRequest): string {
+  const todos = getAgentTodos(request.conversationKey);
+  if (!todos.length) return "";
+  const lines = todos.map(
+    (todo) => `- [${todo.status}] ${todo.content} (${todo.activeForm})`,
+  );
+  return [
+    "SESSION TODO STATE: A task list already exists for this conversation.",
+    "Keep it current with `todo_write` before starting new tracked work and immediately after completing a tracked item.",
+    ...lines,
+  ].join("\n");
+}
+
 function buildTextOnlyModelInstruction(request: AgentRuntimeRequest): string {
   if (isMultimodalRequestSupported(request)) return "";
   const modelLabel = (request.model || "selected model").trim();
@@ -549,6 +563,7 @@ export async function buildAgentInitialMessages(
     buildFigureMineruInstruction(request, matchedSkillIds),
     buildWriteNoteFileInstruction(request, matchedSkillIds),
     buildForcedSkillWholeLibraryInstruction(request),
+    buildTodoProgressInstruction(request),
   ].filter(Boolean);
   const turnGuidanceBlock = buildTurnGuidanceBlock([
     autoReadInstruction,

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -41,6 +41,7 @@ import {
   normalizeHistoryMessages,
 } from "./model/messageBuilder";
 import { classifyWriteNoteDestination } from "./writeNoteDestination";
+import { hydrateAgentTodosFromMessages } from "./tools/todoWrite";
 import { detectSkillIntent } from "./model/skillClassifier";
 import { getAllSkills, getMatchedSkillIds } from "./skills";
 import {
@@ -787,6 +788,10 @@ export class AgentRuntime {
       let transcriptMessagesForPrompt = transcriptSegment.messages.length
         ? transcriptSegment.messages
         : normalizeHistoryMessages(request);
+      hydrateAgentTodosFromMessages(
+        request.conversationKey,
+        transcriptMessagesForPrompt,
+      );
 
       if (isManualCompactRequest(request)) {
         const policy = resolveAgentContextBudgetPolicy();

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -14,6 +14,7 @@ import { createReadAttachmentTool } from "./read/readAttachment";
 import { clearPdfToolCaches } from "./read/pdfToolUtils";
 import { createSearchLiteratureOnlineTool } from "./read/searchLiteratureOnline";
 import { createToolResultReadTool } from "./read/toolResultRead";
+import { clearAgentTodos, createTodoWriteTool } from "./todoWrite";
 import { createDelegatingTool, createRenamedTool } from "./facade";
 
 import { createEditCurrentNoteTool } from "./write/editCurrentNote";
@@ -513,6 +514,7 @@ export function createBuiltInToolRegistry(
   registry.register(markToolTier(fileIO, "advanced"));
   registry.register(markToolTier(runCommand, "advanced"));
   registry.register(markToolTier(zoteroScript, "advanced"));
+  registry.register(createTodoWriteTool());
   registry.register(createToolResultReadTool());
 
   const legacyTools: AgentToolDefinition<any, any>[] = [
@@ -541,5 +543,6 @@ export function createBuiltInToolRegistry(
 }
 
 export function clearAllAgentToolCaches(conversationKey: number): void {
+  clearAgentTodos(conversationKey);
   clearPdfToolCaches(conversationKey);
 }

--- a/src/agent/tools/todoWrite.ts
+++ b/src/agent/tools/todoWrite.ts
@@ -1,0 +1,227 @@
+import type {
+  AgentModelMessage,
+  AgentTodo,
+  AgentTodoStatus,
+  AgentToolDefinition,
+} from "../types";
+import { fail, ok, validateObject } from "./shared";
+
+const MAX_TODOS = 20;
+const MAX_TODO_TEXT_LENGTH = 320;
+const TODO_STATUSES = new Set<AgentTodoStatus>([
+  "pending",
+  "in_progress",
+  "completed",
+]);
+
+const todosByConversation = new Map<number, AgentTodo[]>();
+
+type TodoWriteInput = {
+  todos: AgentTodo[];
+};
+
+type TodoWriteResult = {
+  todos: AgentTodo[];
+  completed: string[];
+  inProgress?: string;
+};
+
+function normalizeTodoText(value: unknown): string {
+  return typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+}
+
+function normalizeTodo(value: unknown): AgentTodo | null {
+  if (!validateObject<Record<string, unknown>>(value)) return null;
+  const content = normalizeTodoText(value.content);
+  const activeForm = normalizeTodoText(value.activeForm);
+  const status = normalizeTodoText(value.status) as AgentTodoStatus;
+  if (!content || !activeForm || !TODO_STATUSES.has(status)) return null;
+  if (
+    content.length > MAX_TODO_TEXT_LENGTH ||
+    activeForm.length > MAX_TODO_TEXT_LENGTH
+  ) {
+    return null;
+  }
+  return { content, activeForm, status };
+}
+
+function cloneTodos(todos: readonly AgentTodo[]): AgentTodo[] {
+  return todos.map((todo) => ({ ...todo }));
+}
+
+function isCompletedTransition(
+  todo: AgentTodo,
+  previousByContent: ReadonlyMap<string, AgentTodo>,
+): boolean {
+  return (
+    todo.status === "completed" &&
+    previousByContent.get(todo.content)?.status !== "completed"
+  );
+}
+
+/** Returns the current in-memory checklist for prompt restoration and tests. */
+export function getAgentTodos(conversationKey: number): AgentTodo[] {
+  return cloneTodos(todosByConversation.get(conversationKey) || []);
+}
+
+/** Removes a checklist when its owning conversation is cleared. */
+export function clearAgentTodos(conversationKey: number): void {
+  todosByConversation.delete(conversationKey);
+}
+
+/**
+ * Rehydrates the list after a plugin restart from the latest todo tool result
+ * retained in the agent transcript. Invalid historical entries are ignored.
+ */
+export function hydrateAgentTodosFromMessages(
+  conversationKey: number,
+  messages: readonly AgentModelMessage[],
+): void {
+  if (todosByConversation.has(conversationKey)) return;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "tool" || message.name !== "todo_write") continue;
+    const content = typeof message.content === "string" ? message.content : "";
+    try {
+      const parsed = JSON.parse(content) as { todos?: unknown };
+      if (!Array.isArray(parsed.todos) || !parsed.todos.length) continue;
+      const todos = parsed.todos.map(normalizeTodo);
+      if (todos.some((todo) => !todo)) continue;
+      const normalized = todos as AgentTodo[];
+      if (
+        normalized.filter((todo) => todo.status === "in_progress").length > 1
+      ) {
+        continue;
+      }
+      todosByConversation.set(conversationKey, cloneTodos(normalized));
+      return;
+    } catch {
+      // Continue searching older tool results when a transcript entry is malformed.
+    }
+  }
+}
+
+export function createTodoWriteTool(): AgentToolDefinition<
+  TodoWriteInput,
+  TodoWriteResult
+> {
+  return {
+    spec: {
+      name: "todo_write",
+      description:
+        "Create or update the session task list for a complex, multi-step agent task. " +
+        "Send the complete current list each time, with content, activeForm, and status for every task.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["todos"],
+        properties: {
+          todos: {
+            type: "array",
+            minItems: 1,
+            maxItems: MAX_TODOS,
+            items: {
+              type: "object",
+              additionalProperties: false,
+              required: ["content", "activeForm", "status"],
+              properties: {
+                content: {
+                  type: "string",
+                  description:
+                    "Imperative task description, for example 'Run the test suite'.",
+                },
+                activeForm: {
+                  type: "string",
+                  description:
+                    "Present-continuous progress label, for example 'Running the test suite'.",
+                },
+                status: {
+                  type: "string",
+                  enum: ["pending", "in_progress", "completed"],
+                },
+              },
+            },
+          },
+        },
+      },
+      mutability: "read",
+      requiresConfirmation: false,
+    },
+    guidance: {
+      matches: () => true,
+      instruction:
+        "Use `todo_write` proactively for complex work with three or more distinct steps, multi-operation workflows, explicit user requests for progress tracking, or a list of requested tasks. Do not use it for a single straightforward action, a simple question, or pure research. When you use it, create the checklist before starting material work; mark the current item `in_progress` before working; update it immediately to `completed` only after it is fully done and verified; then advance the next item. Keep at most one item `in_progress`. Never mark an item completed when the work is partial, a required test or validation fails, or an error/blocker remains. Add follow-up tasks discovered during execution and remove tasks that are no longer relevant. Every `todo_write` call must send the complete current list.",
+    },
+    presentation: {
+      label: "Update Todo List",
+      summaries: {
+        onCall: "Updating task progress",
+        onSuccess: ({ content }) => {
+          const result = content as Partial<TodoWriteResult> | null;
+          const todos = Array.isArray(result?.todos) ? result.todos : [];
+          const completed = todos.filter(
+            (todo) => todo.status === "completed",
+          ).length;
+          return todos.length
+            ? `Task progress: ${completed}/${todos.length} completed`
+            : "Task progress updated";
+        },
+      },
+      buildResultCards: (content) => {
+        const result = content as Partial<TodoWriteResult> | null;
+        const todos = Array.isArray(result?.todos) ? result.todos : [];
+        return todos.map((todo) => ({
+          title: todo.content,
+          status: todo.status,
+        }));
+      },
+    },
+    validate: (args) => {
+      if (!validateObject<Record<string, unknown>>(args)) {
+        return fail("Expected an object with a todos array");
+      }
+      if (!Array.isArray(args.todos) || !args.todos.length) {
+        return fail("todos must contain at least one task");
+      }
+      if (args.todos.length > MAX_TODOS) {
+        return fail(`todos supports at most ${MAX_TODOS} tasks`);
+      }
+      const todos = args.todos.map(normalizeTodo);
+      if (todos.some((todo) => !todo)) {
+        return fail(
+          "Each todo needs non-empty content, activeForm, and a status of pending, in_progress, or completed",
+        );
+      }
+      const normalized = todos as AgentTodo[];
+      const seen = new Set<string>();
+      for (const todo of normalized) {
+        const key = todo.content.toLocaleLowerCase();
+        if (seen.has(key)) return fail("Todo content must be unique");
+        seen.add(key);
+      }
+      if (
+        normalized.filter((todo) => todo.status === "in_progress").length > 1
+      ) {
+        return fail("Only one todo may be in_progress at a time");
+      }
+      return ok({ todos: normalized });
+    },
+    execute: async (input, context) => {
+      const previous = getAgentTodos(context.request.conversationKey);
+      const previousByContent = new Map(
+        previous.map((todo) => [todo.content, todo] as const),
+      );
+      const todos = cloneTodos(input.todos);
+      todosByConversation.set(context.request.conversationKey, todos);
+      const completed = todos
+        .filter((todo) => isCompletedTransition(todo, previousByContent))
+        .map((todo) => todo.content);
+      return {
+        todos,
+        completed,
+        inProgress: todos.find((todo) => todo.status === "in_progress")
+          ?.content,
+      };
+    },
+  };
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -509,6 +509,15 @@ export type AgentRuntimeRequest = AgentRequest & {
   exhaustiveReadBackend?: ExhaustiveReadBackend;
 };
 
+/** A session-scoped execution checklist maintained by the `todo_write` tool. */
+export type AgentTodoStatus = "pending" | "in_progress" | "completed";
+
+export type AgentTodo = {
+  content: string;
+  activeForm: string;
+  status: AgentTodoStatus;
+};
+
 export type AgentAttachmentReadableVia =
   | "read_attachment"
   | "paper_read"
@@ -657,6 +666,11 @@ export type AgentToolPresentationSummary =
  */
 export type AgentToolResultCard = {
   title: string;
+  /**
+   * Optional compact progress state. When present, the read-only result-card
+   * renderer shows an accessible color indicator rather than a text badge.
+   */
+  status?: AgentTodoStatus;
   subtitle?: string;
   body?: string;
   badges?: string[];

--- a/src/modules/contextPanel/agentTrace/render.ts
+++ b/src/modules/contextPanel/agentTrace/render.ts
@@ -1036,22 +1036,33 @@ function renderResultCardList(
   doc: Document,
   cards: AgentToolResultCard[],
 ): HTMLDivElement {
+  const isTodoList = cards.length > 0 && cards.every((card) => card.status);
   const container = doc.createElement("div");
   container.className =
-    "llm-agent-hitl-card llm-search-results llm-search-results-readonly";
+    "llm-agent-hitl-card llm-search-results llm-search-results-readonly" +
+    (isTodoList ? " llm-agent-todo-list" : "");
 
   const header = doc.createElement("div");
   header.className = "llm-agent-hitl-header";
-  header.textContent = `${cards.length} paper${cards.length === 1 ? "" : "s"} found online`;
+  if (isTodoList) {
+    const completed = cards.filter(
+      (card) => card.status === "completed",
+    ).length;
+    header.textContent = `Todo · ${completed}/${cards.length} completed`;
+  } else {
+    header.textContent = `${cards.length} paper${cards.length === 1 ? "" : "s"} found online`;
+  }
   container.appendChild(header);
 
   const list = doc.createElement("div");
   list.className = "llm-search-results-list";
   container.appendChild(list);
 
-  for (const card of cards) {
+  for (const [index, card] of cards.entries()) {
     const row = doc.createElement("div");
-    row.className = "llm-search-results-item";
+    row.className =
+      "llm-search-results-item" +
+      (card.status ? ` llm-agent-todo-item--${card.status}` : "");
 
     const content = doc.createElement("div");
     content.className = "llm-search-results-content";
@@ -1061,8 +1072,31 @@ function renderResultCardList(
 
     const titleEl = doc.createElement("span");
     titleEl.className = "llm-search-results-title";
-    titleEl.textContent = card.title;
+    titleEl.textContent = isTodoList
+      ? `${index + 1}. ${card.title}`
+      : card.title;
     titleRow.appendChild(titleEl);
+
+    if (card.status) {
+      const status = doc.createElement("span");
+      const statusLabel =
+        card.status === "completed"
+          ? "Completed"
+          : card.status === "in_progress"
+            ? "In progress"
+            : "Pending";
+      const statusSymbol =
+        card.status === "completed"
+          ? "✓"
+          : card.status === "in_progress"
+            ? "●"
+            : "○";
+      status.className = `llm-agent-todo-status llm-agent-todo-status--${card.status}`;
+      status.textContent = statusSymbol;
+      status.setAttribute("aria-label", `Status: ${statusLabel}`);
+      status.title = statusLabel;
+      titleRow.appendChild(status);
+    }
 
     if (card.href) {
       const openBtn = doc.createElement("a");

--- a/test/agentTodoWrite.test.ts
+++ b/test/agentTodoWrite.test.ts
@@ -1,0 +1,139 @@
+import { assert } from "chai";
+import {
+  clearAgentTodos,
+  createTodoWriteTool,
+  getAgentTodos,
+  hydrateAgentTodosFromMessages,
+} from "../src/agent/tools/todoWrite";
+
+describe("todo_write", function () {
+  const conversationKey = 941;
+
+  beforeEach(function () {
+    clearAgentTodos(conversationKey);
+  });
+
+  it("tracks one current task and records completion immediately", async function () {
+    const tool = createTodoWriteTool();
+    const initial = tool.validate({
+      todos: [
+        {
+          content: "Inspect selected papers",
+          activeForm: "Inspecting selected papers",
+          status: "in_progress",
+        },
+        {
+          content: "Write the synthesis note",
+          activeForm: "Writing the synthesis note",
+          status: "pending",
+        },
+      ],
+    });
+    assert.isTrue(initial.ok);
+    if (!initial.ok) return;
+    await tool.execute(initial.value, {
+      request: {
+        conversationKey,
+        mode: "agent",
+        userText: "Compare these papers and write a note",
+      },
+      item: null,
+      currentAnswerText: "",
+      modelName: "test",
+    });
+
+    const advanced = tool.validate({
+      todos: [
+        {
+          content: "Inspect selected papers",
+          activeForm: "Inspecting selected papers",
+          status: "completed",
+        },
+        {
+          content: "Write the synthesis note",
+          activeForm: "Writing the synthesis note",
+          status: "in_progress",
+        },
+      ],
+    });
+    assert.isTrue(advanced.ok);
+    if (!advanced.ok) return;
+    const result = await tool.execute(advanced.value, {
+      request: {
+        conversationKey,
+        mode: "agent",
+        userText: "Compare these papers and write a note",
+      },
+      item: null,
+      currentAnswerText: "",
+      modelName: "test",
+    });
+
+    assert.deepEqual(result.completed, ["Inspect selected papers"]);
+    assert.equal(result.inProgress, "Write the synthesis note");
+    assert.deepEqual(getAgentTodos(conversationKey), result.todos);
+  });
+
+  it("rejects concurrent in-progress tasks and malformed items", function () {
+    const tool = createTodoWriteTool();
+    const concurrent = tool.validate({
+      todos: [
+        { content: "Read", activeForm: "Reading", status: "in_progress" },
+        { content: "Write", activeForm: "Writing", status: "in_progress" },
+      ],
+    });
+    assert.isFalse(concurrent.ok);
+
+    const malformed = tool.validate({
+      todos: [{ content: "Read", activeForm: "", status: "completed" }],
+    });
+    assert.isFalse(malformed.ok);
+  });
+
+  it("builds compact title-only cards with a semantic status", function () {
+    const tool = createTodoWriteTool();
+    const cards = tool.presentation?.buildResultCards?.({
+      todos: [
+        {
+          content: "Inspect selected papers",
+          activeForm: "Inspecting selected papers",
+          status: "completed",
+        },
+      ],
+    });
+
+    assert.deepEqual(cards, [
+      {
+        title: "Inspect selected papers",
+        status: "completed",
+      },
+    ]);
+  });
+
+  it("restores the latest checklist from an agent transcript", function () {
+    hydrateAgentTodosFromMessages(conversationKey, [
+      {
+        role: "tool",
+        tool_call_id: "todo-call",
+        name: "todo_write",
+        content: JSON.stringify({
+          todos: [
+            {
+              content: "Verify the exported note",
+              activeForm: "Verifying the exported note",
+              status: "in_progress",
+            },
+          ],
+        }),
+      },
+    ]);
+
+    assert.deepEqual(getAgentTodos(conversationKey), [
+      {
+        content: "Verify the exported note",
+        activeForm: "Verifying the exported note",
+        status: "in_progress",
+      },
+    ]);
+  });
+});

--- a/test/toolSurfaceRefactor.test.ts
+++ b/test/toolSurfaceRefactor.test.ts
@@ -118,6 +118,7 @@ describe("semantic tool surface", function () {
       "note_write",
       "paper_read",
       "run_command",
+      "todo_write",
       "undo_last_action",
       "zotero_script",
     ]);


### PR DESCRIPTION
## Summary

- Add a Claude Code-inspired `todo_write` tool to the built-in Agent runtime for complex, multi-step work and explicit progress-tracking requests.
- Keep the Todo checklist session-scoped, validate its full-state updates, and restore it from the Agent transcript after a restart.
- Render compact Todo cards with ordinal task titles and accessible status symbols: pending `○`, in progress `●`, and completed `✓`.

<img width="544" height="303" alt="image" src="https://github.com/user-attachments/assets/b7bf1f24-6858-4785-94fd-226e5d114a32" />


## Behavior

The model is guided to create a Todo list before material work on complex workflows, keep at most one task in progress, and only complete a task after required work and validation succeed. Todo state tracks progress only; it does not replace normal Agent tool calls.

## Validation

- `npm run test:unit` — 2694 passing, 1 pending
- `npm run typecheck`
- `npx eslint` on touched TypeScript files
- `npx prettier --write` on touched files
- `git diff --check`
- `npm run build`
