### PR TITLE
Fix Codex auth transport fallback and live model discovery

### DIFF
--- a/src/agent/model/adapter.ts
+++ b/src/agent/model/adapter.ts
@@ -5,6 +5,7 @@ import type {
   AgentModelMessage,
   AgentModelStep,
   AgentRuntimeRequest,
+  AgentEvent,
   ToolSpec,
 } from "../types";
 
@@ -25,6 +26,9 @@ export type AgentStepParams = {
   onTextDelta?: (delta: string) => void | Promise<void>;
   onReasoning?: (event: ReasoningEvent) => void | Promise<void>;
   onUsage?: (usage: UsageStats) => void | Promise<void>;
+  onCodexToolActivity?: (
+    event: Extract<AgentEvent, { type: "codex_tool_activity" }>,
+  ) => void | Promise<void>;
   onToolCall?: (call: AgentToolCall) => Promise<AgentAdapterToolCallResult>;
 };
 

--- a/src/agent/model/codexResponses.ts
+++ b/src/agent/model/codexResponses.ts
@@ -1,9 +1,20 @@
 import {
   buildReasoningPayload,
   buildPromptCachePayloadHints,
+  isCodexFetchTransportError,
   postWithReasoningFallback,
   resolveRequestAuthState,
 } from "../../utils/llmClient";
+import type { ChatMessage, MessageContent } from "../../shared/llm";
+import { getCodexBinaryPathPref } from "../../codexAppServer/prefs";
+import { runCodexAuthAppServerTurn } from "../../utils/codexAuthAppServerTransport";
+import {
+  addZoteroMcpToolActivityObserver,
+  buildZoteroMcpConfigValue,
+  getZoteroMcpServerName,
+  registerScopedZoteroMcpScope,
+  type ZoteroMcpToolActivityEvent,
+} from "../mcp/server";
 import { normalizeTemperature } from "../../utils/normalization";
 import { resolveProviderTransportEndpoint } from "../../utils/providerTransport";
 import type {
@@ -13,7 +24,10 @@ import type {
 } from "../types";
 import type { AgentModelAdapter, AgentStepParams } from "./adapter";
 import { buildAgentModelCapabilities } from "./contentCapabilities";
-import { resolveRequestContentInputs } from "./messageBuilder";
+import {
+  resolveRequestContentInputs,
+  stringifyMessageContent,
+} from "./messageBuilder";
 import {
   buildResponsesContinuationInput,
   buildResponsesInitialInput,
@@ -36,6 +50,128 @@ function isCodexAuthRequest(request: AgentRuntimeRequest): boolean {
   );
 }
 
+type CodexAppServerTurnRunner = typeof runCodexAuthAppServerTurn;
+
+function prepareCodexAgentFallbackMcpServer(
+  request: AgentRuntimeRequest,
+): import("../../utils/codexAuthAppServerTransport").CodexTurnMcpServer | undefined {
+  // Unit tests and non-Zotero consumers can exercise the transport adapter
+  // without constructing the local MCP endpoint.
+  if (typeof Zotero === "undefined") return undefined;
+  const selectedPaper =
+    request.selectedPaperContexts?.[0] ||
+    request.fullTextPaperContexts?.[0] ||
+    request.pinnedPaperContexts?.[0] ||
+    request.pdfPaperContexts?.[0];
+  const kind = request.conversationKind === "paper" ? "paper" : "global";
+  const fallbackActiveItemId = request.activeItemId || request.item?.id;
+  const paperItemID =
+    kind === "paper"
+      ? selectedPaper?.itemId || fallbackActiveItemId
+      : undefined;
+  const scopedMcp = registerScopedZoteroMcpScope({
+    conversationKey: request.conversationKey,
+    conversationGeneration: request.conversationGeneration,
+    libraryID: request.libraryID,
+    kind,
+    paperItemID,
+    activeItemId: paperItemID || fallbackActiveItemId,
+    activeContextItemId: selectedPaper?.contextItemId,
+    title:
+      selectedPaper?.title ||
+      (request.item && typeof request.item.getField === "function"
+        ? String(request.item.getField("title") || "")
+        : undefined),
+    userText: request.userText,
+    model: request.model,
+    codexPath: getCodexBinaryPathPref(),
+    reasoning: request.reasoning,
+    exhaustiveReadBackend: "codex_responses",
+    paperContext: selectedPaper,
+    selectedPaperContexts: request.selectedPaperContexts,
+    pdfPaperContexts: request.pdfPaperContexts,
+    fullTextPaperContexts: request.fullTextPaperContexts,
+    pinnedPaperContexts: request.pinnedPaperContexts,
+    selectedCollectionContexts: request.selectedCollectionContexts,
+    selectedTagContexts: request.selectedTagContexts,
+  });
+  return {
+    serverName: getZoteroMcpServerName(),
+    configValue: buildZoteroMcpConfigValue({
+      scopeToken: scopedMcp.token,
+      required: true,
+    }),
+    clear: scopedMcp.clear,
+  };
+}
+
+export function buildCodexFallbackMcpToolActivityEvent(
+  event: ZoteroMcpToolActivityEvent,
+): Extract<import("../types").AgentEvent, { type: "codex_tool_activity" }> {
+  return {
+    type: "codex_tool_activity",
+    itemId: `mcp:${event.requestId || `${event.toolName}:${event.timestamp}`}`,
+    phase: event.phase,
+    toolName: event.toolName,
+    toolLabel: event.toolLabel,
+    serverName: event.serverName,
+    args: event.arguments,
+    ok: event.ok,
+    text: event.error,
+    artifacts: event.artifacts,
+  };
+}
+
+function toAppServerContent(
+  content: import("../types").AgentModelMessage["content"],
+): MessageContent {
+  if (typeof content === "string") return content;
+  return content.map((part) =>
+    part.type === "image_url"
+      ? part
+      : {
+          type: "text" as const,
+          text:
+            part.type === "text"
+              ? part.text
+              : `[Prepared file: ${part.file_ref.name}]`,
+        },
+  );
+}
+
+/**
+ * The app-server transport accepts chat messages rather than the Agent
+ * runtime's tool-role transcript. Preserve tool evidence as explicit text so
+ * a Gecko fetch failure can be retried without losing the current turn.
+ */
+export function buildCodexAgentAppServerMessages(
+  messages: import("../types").AgentModelMessage[],
+): ChatMessage[] {
+  return messages.map((message) => {
+    if (message.role === "tool") {
+      return {
+        role: "user",
+        content:
+          `[Tool result: ${message.name}, call_id=${message.tool_call_id}]\n` +
+          message.content,
+      };
+    }
+
+    let content = toAppServerContent(message.content);
+    if (message.role === "assistant" && message.tool_calls?.length) {
+      const toolCalls = message.tool_calls
+        .map(
+          (call) =>
+            `[Tool call: ${call.name}, call_id=${call.id}]\n${JSON.stringify(call.arguments)}`,
+        )
+        .join("\n");
+      const text = stringifyMessageContent(message.content);
+      content = [text, toolCalls].filter(Boolean).join("\n");
+    }
+    return { role: message.role, content };
+  });
+}
+
 export {
   limitNormalizedResponsesStep,
   normalizeResponsesStepFromPayload as normalizeStepFromPayload,
@@ -44,6 +180,10 @@ export {
 
 export class CodexResponsesAgentAdapter implements AgentModelAdapter {
   private conversationItems: unknown[] | null = null;
+
+  constructor(
+    private readonly runAppServerTurn: CodexAppServerTurnRunner = runCodexAuthAppServerTurn,
+  ) {}
 
   getCapabilities(request: AgentRuntimeRequest): AgentModelCapabilities {
     return buildAgentModelCapabilities({
@@ -103,41 +243,109 @@ export class CodexResponsesAgentAdapter implements AgentModelAdapter {
       protocol: "codex_responses",
       apiBase: request.apiBase || "",
     });
-    const response = await postWithReasoningFallback({
-      url,
-      auth,
-      modelName: request.model,
-      initialReasoning: request.reasoning,
-      buildPayload: (reasoningOverride) => {
-        const reasoningPayload = buildReasoningPayload(
-          reasoningOverride,
-          true,
-          request.model,
-          request.apiBase,
-          "codex_responses",
-        );
-        return {
-          model: request.model,
-          instructions,
-          input: inputItems,
-          ...buildPromptCachePayloadHints(request.contextCache),
-          include: ["reasoning.encrypted_content"],
-          tools: buildResponsesFunctionTools(params.tools),
-          tool_choice: "auto",
-          store: false,
-          stream: true,
-          ...reasoningPayload.extra,
-          ...(reasoningPayload.omitTemperature
-            ? {}
-            : {
-                temperature: normalizeTemperature(
-                  request.advanced?.temperature,
-                ),
-              }),
-        };
-      },
-      signal: params.signal,
-    });
+    let response: Response;
+    try {
+      response = await postWithReasoningFallback({
+        url,
+        auth,
+        modelName: request.model,
+        initialReasoning: request.reasoning,
+        buildPayload: (reasoningOverride) => {
+          const reasoningPayload = buildReasoningPayload(
+            reasoningOverride,
+            true,
+            request.model,
+            request.apiBase,
+            "codex_responses",
+          );
+          return {
+            model: request.model,
+            instructions,
+            input: inputItems,
+            ...buildPromptCachePayloadHints(request.contextCache),
+            include: ["reasoning.encrypted_content"],
+            tools: buildResponsesFunctionTools(params.tools),
+            tool_choice: "auto",
+            store: false,
+            stream: true,
+            ...reasoningPayload.extra,
+            ...(reasoningPayload.omitTemperature
+              ? {}
+              : {
+                  temperature: normalizeTemperature(
+                    request.advanced?.temperature,
+                  ),
+                }),
+          };
+        },
+        signal: params.signal,
+      });
+    } catch (error) {
+      if (!isCodexAuthRequest(request) || !isCodexFetchTransportError(error)) {
+        throw error;
+      }
+      (
+        globalThis as typeof globalThis & {
+          ztoolkit?: { log?: (...args: unknown[]) => void };
+        }
+      ).ztoolkit?.log?.(
+        "LLM Agent: Zotero fetch failed for Codex auth; retrying through local app-server",
+        error,
+      );
+      const mcpServer = prepareCodexAgentFallbackMcpServer(request);
+      let pendingMcpActivity = Promise.resolve();
+      const unregisterMcpToolActivity = mcpServer
+        ? addZoteroMcpToolActivityObserver((event) => {
+            if (
+              event.conversationKey &&
+              event.conversationKey !== request.conversationKey
+            ) {
+              return;
+            }
+            pendingMcpActivity = pendingMcpActivity.then(async () => {
+              try {
+                await params.onCodexToolActivity?.(
+                  buildCodexFallbackMcpToolActivityEvent(event),
+                );
+              } catch (activityError) {
+                (
+                  globalThis as typeof globalThis & {
+                    ztoolkit?: { log?: (...args: unknown[]) => void };
+                  }
+                ).ztoolkit?.log?.(
+                  "LLM Agent: failed to persist fallback MCP activity",
+                  activityError,
+                );
+              }
+            });
+          })
+        : () => undefined;
+      let text: string;
+      try {
+        text = await this.runAppServerTurn({
+          model: request.model || "",
+          messages: buildCodexAgentAppServerMessages(params.messages),
+          reasoning: request.reasoning,
+          signal: params.signal,
+          codexPath: getCodexBinaryPathPref(),
+          onDelta: params.onTextDelta,
+          onReasoning: params.onReasoning,
+          onUsage: params.onUsage,
+          mcpServer,
+        });
+      } finally {
+        unregisterMcpToolActivity();
+        await pendingMcpActivity;
+      }
+      // The fallback owns the complete turn, so any direct Responses state is
+      // stale and must not be reused if Gecko fetch starts working later.
+      this.resetState();
+      return {
+        kind: "final",
+        text,
+        assistantMessage: { role: "assistant", content: text },
+      };
+    }
     const normalized = limitNormalizedResponsesStep(
       response.body
         ? await parseResponsesStepStream(

--- a/src/agent/model/codexResponses.ts
+++ b/src/agent/model/codexResponses.ts
@@ -1,10 +1,10 @@
 import {
   buildReasoningPayload,
   buildPromptCachePayloadHints,
-  isCodexFetchTransportError,
   postWithReasoningFallback,
   resolveRequestAuthState,
 } from "../../utils/llmClient";
+import { isCodexFetchTransportError } from "../../utils/codexTransportError";
 import type { ChatMessage, MessageContent } from "../../shared/llm";
 import { getCodexBinaryPathPref } from "../../codexAppServer/prefs";
 import { runCodexAuthAppServerTurn } from "../../utils/codexAuthAppServerTransport";
@@ -54,7 +54,9 @@ type CodexAppServerTurnRunner = typeof runCodexAuthAppServerTurn;
 
 function prepareCodexAgentFallbackMcpServer(
   request: AgentRuntimeRequest,
-): import("../../utils/codexAuthAppServerTransport").CodexTurnMcpServer | undefined {
+):
+  | import("../../utils/codexAuthAppServerTransport").CodexTurnMcpServer
+  | undefined {
   // Unit tests and non-Zotero consumers can exercise the transport adapter
   // without constructing the local MCP endpoint.
   if (typeof Zotero === "undefined") return undefined;

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -1346,6 +1346,9 @@ export class AgentRuntime {
               ...(cacheProvider ? { cacheProvider } : {}),
             });
           },
+          onCodexToolActivity: async (activity) => {
+            await emit(activity);
+          },
           onToolCall: async (call) => {
             await rollbackStepStreamedText();
             const outcome = await executeToolWorkflow(call, round, {

--- a/src/codexAppServer/mcpSetup.ts
+++ b/src/codexAppServer/mcpSetup.ts
@@ -16,6 +16,8 @@ import {
 } from "../utils/codexAppServerProcess";
 
 const DEFAULT_CODEX_APP_SERVER_NATIVE_PROCESS_KEY = "codex_app_server_native";
+const DEFAULT_CODEX_APP_SERVER_MCP_STATUS_PROCESS_KEY =
+  "codex_app_server_mcp_status";
 const MCP_PREFLIGHT_SUCCESS_TTL_MS = 5 * 60 * 1000;
 const MCP_PREFLIGHT_FAILURE_TTL_MS = 10 * 1000;
 export const REQUIRED_CODEX_ZOTERO_MCP_TOOL_NAMES = [
@@ -472,7 +474,19 @@ export async function preflightCodexZoteroMcpServer(
 export async function readCodexNativeMcpSetupStatus(
   params: SetupParams = {},
 ): Promise<CodexNativeMcpSetupStatus> {
-  const proc = await resolveProcess(params);
+  // Status discovery sends several potentially slow catalog requests in
+  // parallel. Keep those optional probes off the native turn process: a
+  // request timeout intentionally terminates its CodexAppServerProcess, which
+  // would otherwise abort an Agent/legacy-provider turn started while the
+  // preferences pane is checking MCP health.
+  const processParams =
+    params.proc || params.processKey
+      ? params
+      : {
+          ...params,
+          processKey: DEFAULT_CODEX_APP_SERVER_MCP_STATUS_PROCESS_KEY,
+        };
+  const proc = await resolveProcess(processParams);
   const errors: string[] = [];
   const serverName = params.serverName || ZOTERO_MCP_SERVER_NAME;
   const serverUrl = params.serverUrl || getZoteroMcpServerUrl();

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -245,11 +245,11 @@ const setPref = (key: PrefKey, value: string) =>
 const CUSTOMIZED_API_HELPER_TEXT =
   "Choose a preset above, or switch to Customized to enter a full base URL or endpoint manually.";
 const LEGACY_CODEX_AUTH_HELPER_TEXT =
-  "Legacy direct ChatGPT/Codex backend mode. Existing users can keep using it in this release. New users should use Codex App Server. Planned for deprecation in a future release after app-server validation.";
+  "Compatibility mode for existing Codex-auth provider entries. Requests reuse the local Codex app-server runtime to avoid Zotero network transport failures.";
 const CODEX_APP_SERVER_HELPER_TEXT =
   "Recommended official Codex integration. Runs the local `codex app-server` CLI as the native Codex runtime. Run `codex login` first.";
 const LEGACY_CODEX_API_HELPER_TEXT =
-  "Legacy direct backend URL. Usually uses https://chatgpt.com/backend-api/codex/responses. Existing users can keep it in this release, but new users should use Codex App Server. Planned for deprecation in a future release after app-server validation.";
+  "Kept for legacy configuration compatibility. Codex-auth requests are sent through the local Codex app-server runtime.";
 const CODEX_APP_SERVER_PROTOCOL_HELPER_TEXT =
   "Uses Codex responses with the local codex app-server transport.";
 const CODEX_APP_SERVER_PATH_HELPER_TEXT_WINDOWS =
@@ -1848,6 +1848,38 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
       modelsHeaderRow.appendChild(addModelBtn);
       modelsWrap.appendChild(modelsHeaderRow);
 
+      let codexProviderModelSuggestions: HTMLDataListElement | null = null;
+      if (group.authMode === "codex_auth") {
+        codexProviderModelSuggestions = doc.createElementNS(
+          HTML_NS,
+          "datalist",
+        ) as HTMLDataListElement;
+        codexProviderModelSuggestions.id = `${config.addonRef}-provider-${group.id}-codex-models`;
+        modelsWrap.appendChild(codexProviderModelSuggestions);
+        void loadCodexAppServerModelCatalog({
+          codexPath: getConfiguredCodexAppServerBinaryPath(),
+        })
+          .then((catalog) => {
+            const options = catalog.models.map((model) => {
+              const option = doc.createElementNS(
+                HTML_NS,
+                "option",
+              ) as HTMLOptionElement;
+              option.value = model.model;
+              option.label = model.displayName;
+              option.title = model.description;
+              return option;
+            });
+            codexProviderModelSuggestions?.replaceChildren(...options);
+          })
+          .catch((error) => {
+            ztoolkit.log(
+              "Codex auth provider: failed to load model suggestions",
+              error,
+            );
+          });
+      }
+
       const syncAddModelBtn = () => {
         const canAdd = !hasEmptyModel(group);
         addModelBtn.disabled = !canAdd;
@@ -1893,6 +1925,9 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
         }
         modelInput.placeholder =
           modelIndex === 0 ? profile.modelPlaceholder : "";
+        if (codexProviderModelSuggestions) {
+          modelInput.setAttribute("list", codexProviderModelSuggestions.id);
+        }
 
         const testBtn = el(
           doc,
@@ -2754,6 +2789,32 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
   }
 
   let codexReasoningCatalogRefreshId = 0;
+  let codexModelSuggestions: HTMLDataListElement | null = null;
+  if (codexAppServerModelInput) {
+    codexModelSuggestions = doc.createElementNS(
+      HTML_NS,
+      "datalist",
+    ) as HTMLDataListElement;
+    codexModelSuggestions.id = `${config.addonRef}-codex-app-server-model-options`;
+    codexAppServerModelInput.setAttribute("list", codexModelSuggestions.id);
+    codexAppServerModelInput.parentElement?.appendChild(codexModelSuggestions);
+  }
+  const renderCodexModelSuggestions = (
+    models: CodexAppServerModelCatalogEntry[],
+  ) => {
+    if (!codexModelSuggestions) return;
+    const options = models.map((model) => {
+      const option = doc.createElementNS(
+        HTML_NS,
+        "option",
+      ) as HTMLOptionElement;
+      option.value = model.model;
+      option.label = model.displayName;
+      option.title = model.description;
+      return option;
+    });
+    codexModelSuggestions.replaceChildren(...options);
+  };
   const renderCodexReasoningOptions = (
     models: CodexAppServerModelCatalogEntry[],
     catalogReady: boolean,
@@ -2790,6 +2851,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
         codexPath: getConfiguredCodexAppServerBinaryPath(),
       });
       if (refreshId !== codexReasoningCatalogRefreshId) return;
+      renderCodexModelSuggestions(catalog.models);
       renderCodexReasoningOptions(catalog.models, true);
     } catch (error) {
       if (refreshId !== codexReasoningCatalogRefreshId) return;
@@ -2797,6 +2859,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
         "Codex app-server: failed to load reasoning options in preferences",
         error,
       );
+      renderCodexModelSuggestions([]);
       renderCodexReasoningOptions([], false);
     }
   };
@@ -2849,9 +2912,33 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
         codexAppServerStatus.style.color = "var(--fill-secondary, #888)";
         codexAppServerStatus.textContent = t("Testing…");
         try {
+          const selectedModel = (
+            codexAppServerModelInput?.value || getCodexRuntimeModelPref()
+          ).trim();
+          const catalog = await loadCodexAppServerModelCatalog({
+            codexPath: getConfiguredCodexAppServerBinaryPath(),
+          });
+          renderCodexModelSuggestions(catalog.models);
+          if (
+            selectedModel &&
+            !catalog.models.some(
+              (entry) =>
+                entry.model.toLowerCase() === selectedModel.toLowerCase(),
+            )
+          ) {
+            throw new Error(
+              t(
+                'The installed Codex CLI does not list "%model%". Available models: %models%.',
+              )
+                .replace("%model%", selectedModel)
+                .replace(
+                  "%models%",
+                  catalog.models.map((entry) => entry.model).join(", "),
+                ),
+            );
+          }
           const result = await runCodexAppServerConnectionTest({
-            modelName:
-              codexAppServerModelInput?.value || getCodexRuntimeModelPref(),
+            modelName: selectedModel,
             codexPath: getConfiguredCodexAppServerBinaryPath(),
           });
           codexAppServerStatus.textContent = `${t("✓ Success — model says: ")}"${result.reply}"`;

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -245,11 +245,11 @@ const setPref = (key: PrefKey, value: string) =>
 const CUSTOMIZED_API_HELPER_TEXT =
   "Choose a preset above, or switch to Customized to enter a full base URL or endpoint manually.";
 const LEGACY_CODEX_AUTH_HELPER_TEXT =
-  "Compatibility mode for existing Codex-auth provider entries. Requests reuse the local Codex app-server runtime to avoid Zotero network transport failures.";
+  "Compatibility mode for existing Codex-auth provider entries. Requests use the configured legacy endpoint first, then retry through an isolated local Codex app-server only when Zotero's network transport fails.";
 const CODEX_APP_SERVER_HELPER_TEXT =
   "Recommended official Codex integration. Runs the local `codex app-server` CLI as the native Codex runtime. Run `codex login` first.";
 const LEGACY_CODEX_API_HELPER_TEXT =
-  "Kept for legacy configuration compatibility. Codex-auth requests are sent through the local Codex app-server runtime.";
+  "Kept for legacy configuration compatibility. This endpoint is tried first; Zotero network transport failures retry through an isolated local Codex app-server.";
 const CODEX_APP_SERVER_PROTOCOL_HELPER_TEXT =
   "Uses Codex responses with the local codex app-server transport.";
 const CODEX_APP_SERVER_PATH_HELPER_TEXT_WINDOWS =
@@ -745,7 +745,10 @@ function resolveCodexAuthPath(): string {
   return joinLocalPath(home, ".codex", "auth.json");
 }
 
-async function readCodexAccessToken(): Promise<string> {
+async function readCodexAuthState(): Promise<{
+  accessToken: string;
+  accountId: string;
+}> {
   const authPath = resolveCodexAuthPath();
   const io = ztoolkit.getGlobal("IOUtils") as
     | {
@@ -761,7 +764,7 @@ async function readCodexAccessToken(): Promise<string> {
   const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
   const raw = new TextDecoder("utf-8").decode(bytes);
   const parsed = JSON.parse(raw) as {
-    tokens?: { access_token?: string };
+    tokens?: { access_token?: string; account_id?: string };
   };
   const token = parsed?.tokens?.access_token?.trim() || "";
   if (!token) {
@@ -769,7 +772,10 @@ async function readCodexAccessToken(): Promise<string> {
       "No access token found in ~/.codex/auth.json. Run `codex login` first.",
     );
   }
-  return token;
+  return {
+    accessToken: token,
+    accountId: parsed?.tokens?.account_id?.trim() || "",
+  };
 }
 
 // ── Style tokens ───────────────────────────────────────────────────
@@ -2265,14 +2271,15 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
               statusLine.style.color = "green";
               return;
             }
-            const apiKey =
-              authMode === "codex_auth"
-                ? await readCodexAccessToken()
-                : authMode === "copilot_auth"
-                  ? await resolveCopilotAccessToken({
-                      githubToken: group.apiKey.trim(),
-                    })
-                  : group.apiKey.trim();
+            const codexAuthState =
+              authMode === "codex_auth" ? await readCodexAuthState() : null;
+            const apiKey = codexAuthState
+              ? codexAuthState.accessToken
+              : authMode === "copilot_auth"
+                ? await resolveCopilotAccessToken({
+                    githubToken: group.apiKey.trim(),
+                  })
+                : group.apiKey.trim();
             const modelName = (
               modelEntry.model ||
               profile.defaultModel ||
@@ -2303,6 +2310,7 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
               apiBase,
               apiKey,
               modelName,
+              codexAccountId: codexAuthState?.accountId,
             });
             statusLine.textContent =
               `${t("✓ Success — model says: ")}"${result.reply}"\n` +

--- a/src/utils/codexAppServerProcess.ts
+++ b/src/utils/codexAppServerProcess.ts
@@ -92,6 +92,10 @@ export type CodexAppServerInjectItemsSupport =
 
 export type CodexAppServerProcessOptions = {
   codexPath?: string;
+  /** CLI config overrides applied before `app-server` starts. */
+  configOverrides?: string[];
+  /** Environment entries appended only for this app-server process. */
+  environment?: Record<string, string>;
 };
 
 type CodexLaunchInvocation = {
@@ -190,15 +194,29 @@ export class CodexAppServerProcess {
     let args: string[];
     let environment: Record<string, string> | undefined;
     if (info.platform === "windows") {
-      const invocation = await buildWindowsCodexInvocation(binary, info);
+      const invocation = await buildWindowsCodexInvocation(
+        binary,
+        info,
+        options.configOverrides,
+      );
       command = invocation.command;
       args = invocation.args;
-      environment = invocation.environment;
+      environment = {
+        ...(invocation.environment || {}),
+        ...(options.environment || {}),
+      };
     } else {
-      const invocation = await buildPosixCodexInvocation(binary, info);
+      const invocation = await buildPosixCodexInvocation(
+        binary,
+        info,
+        options.configOverrides,
+      );
       command = invocation.command;
       args = invocation.args;
-      environment = invocation.environment;
+      environment = {
+        ...(invocation.environment || {}),
+        ...(options.environment || {}),
+      };
     }
     let proc: any;
     try {
@@ -1773,10 +1791,42 @@ function buildPrefixCodexCandidates(params: {
   ];
 }
 
-function buildWindowsShellCommand(binary: string): string {
-  return /\s/.test(binary)
-    ? `""${binary}" app-server"`
-    : `${binary} app-server`;
+function normalizeCodexConfigOverrides(values?: string[]): string[] {
+  return Array.isArray(values)
+    ? values.map((value) => String(value || "").trim()).filter(Boolean)
+    : [];
+}
+
+export function buildCodexAppServerArguments(
+  configOverrides?: string[],
+): string[] {
+  return [
+    "app-server",
+    ...normalizeCodexConfigOverrides(configOverrides).flatMap((value) => [
+      "-c",
+      value,
+    ]),
+  ];
+}
+
+function quoteWindowsShellArgument(value: string): string {
+  return /[\s"&|<>^]/.test(value)
+    ? `"${value.replace(/"/g, '""')}"`
+    : value;
+}
+
+function buildWindowsShellCommand(
+  binary: string,
+  configOverrides?: string[],
+): string {
+  const binaryCommand = /\s/.test(binary) ? `"${binary}"` : binary;
+  const command = [
+    binaryCommand,
+    ...buildCodexAppServerArguments(configOverrides).map(
+      quoteWindowsShellArgument,
+    ),
+  ].join(" ");
+  return /\s/.test(binary) ? `"${command}"` : command;
 }
 
 function splitWindowsCommandLine(value: string): string[] {
@@ -1846,6 +1896,7 @@ function getWindowsDirectory(path: string): string {
 async function buildWindowsCodexInvocation(
   binary: string,
   info: ReturnType<typeof getRuntimePlatformInfo>,
+  configOverrides?: string[],
 ): Promise<CodexLaunchInvocation> {
   if (isUnsupportedWindowsWslCodexReference(binary)) {
     throw createWindowsWslCodexUnsupportedError();
@@ -1854,7 +1905,10 @@ async function buildWindowsCodexInvocation(
   const directory = getWindowsDirectory(binary);
   if (directory && /\.cmd$/i.test(binary)) {
     const nativeInvocation =
-      await resolveWindowsNpmNativeCodexInvocation(directory);
+      await resolveWindowsNpmNativeCodexInvocation(
+        directory,
+        configOverrides,
+      );
     if (nativeInvocation) return nativeInvocation;
 
     const nodePath = joinRuntimePath("\\", directory, "node.exe");
@@ -1862,7 +1916,7 @@ async function buildWindowsCodexInvocation(
     if ((await pathExists(nodePath)) && (await pathExists(codexJsPath))) {
       return {
         command: nodePath,
-        args: [codexJsPath, "app-server"],
+        args: [codexJsPath, ...buildCodexAppServerArguments(configOverrides)],
       };
     }
   }
@@ -1870,20 +1924,26 @@ async function buildWindowsCodexInvocation(
   if (/\.(exe|com)$/i.test(binary)) {
     return {
       command: binary,
-      args: ["app-server"],
+      args: buildCodexAppServerArguments(configOverrides),
     };
   }
 
   // npm shims are usually batch scripts, and bare `codex` needs PATHEXT lookup.
   return {
     command: info.shellPath,
-    args: ["/d", "/s", info.shellFlag, buildWindowsShellCommand(binary)],
+    args: [
+      "/d",
+      "/s",
+      info.shellFlag,
+      buildWindowsShellCommand(binary, configOverrides),
+    ],
   };
 }
 
 async function buildPosixCodexInvocation(
   binary: string,
   info: ReturnType<typeof getRuntimePlatformInfo>,
+  configOverrides?: string[],
 ): Promise<CodexLaunchInvocation> {
   const env = getCodexRuntimeEnv();
   const homeDir = getNonEmptyEnvValue(env, "HOME") || "";
@@ -1929,7 +1989,7 @@ async function buildPosixCodexInvocation(
   );
   return {
     command: binary,
-    args: ["app-server"],
+    args: buildCodexAppServerArguments(configOverrides),
     ...(path ? { environment: { PATH: path } } : {}),
   };
 }
@@ -1948,6 +2008,7 @@ function getWindowsNpmCodexJsPath(directory: string): string {
 
 async function resolveWindowsNpmNativeCodexInvocation(
   directory: string,
+  configOverrides?: string[],
 ): Promise<{
   command: string;
   args: string[];
@@ -1994,7 +2055,7 @@ async function resolveWindowsNpmNativeCodexInvocation(
     }
     return {
       command: nativeBinary,
-      args: ["app-server"],
+      args: buildCodexAppServerArguments(configOverrides),
       environment,
     };
   }
@@ -2345,7 +2406,20 @@ function buildProcessCacheKey(
   options: CodexAppServerProcessOptions = {},
 ): string {
   const codexPath = resolveCodexAppServerBinaryPath(options.codexPath);
-  return codexPath ? `${cacheKey}\u0000${codexPath}` : cacheKey;
+  const configOverrides = normalizeCodexConfigOverrides(
+    options.configOverrides,
+  );
+  const environment = Object.fromEntries(
+    Object.entries(options.environment || {}).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+  return [
+    cacheKey,
+    codexPath || "",
+    JSON.stringify(configOverrides),
+    JSON.stringify(environment),
+  ].join("\u0000");
 }
 
 export function destroyCachedCodexAppServerProcess(

--- a/src/utils/codexAuthAppServerTransport.ts
+++ b/src/utils/codexAuthAppServerTransport.ts
@@ -1,0 +1,121 @@
+import type {
+  ChatMessage,
+  ReasoningConfig,
+  ReasoningEvent,
+  UsageStats,
+} from "../shared/llm";
+import {
+  buildLegacyCodexAppServerChatInput,
+  prepareCodexAppServerChatTurn,
+} from "./codexAppServerInput";
+import {
+  extractCodexAppServerThreadId,
+  extractCodexAppServerTurnId,
+  getOrCreateCodexAppServerProcess,
+  isCodexAppServerThreadStartInstructionsUnsupportedError,
+  resolveCodexAppServerBinaryPath,
+  resolveCodexAppServerReasoningParams,
+  resolveCodexAppServerTurnInputWithFallback,
+  waitForCodexAppServerTurnCompletion,
+} from "./codexAppServerProcess";
+
+// Intentionally share the process used by the native Agent runtime. This lets
+// the legacy provider recover from Gecko fetch failures without launching a
+// second Codex runtime, and lets the Agent connection test warm the same
+// process used by real turns.
+export const CODEX_SHARED_APP_SERVER_PROCESS_KEY = "codex_app_server_native";
+
+export async function runCodexAuthAppServerTurn(params: {
+  model: string;
+  messages: ChatMessage[];
+  reasoning?: ReasoningConfig;
+  signal?: AbortSignal;
+  codexPath?: string;
+  onDelta?: (delta: string) => void;
+  onReasoning?: (event: ReasoningEvent) => void;
+  onUsage?: (usage: UsageStats) => void;
+}): Promise<string> {
+  const processOptions = {
+    codexPath: resolveCodexAppServerBinaryPath(params.codexPath),
+  };
+  const proc = await getOrCreateCodexAppServerProcess(
+    CODEX_SHARED_APP_SERVER_PROCESS_KEY,
+    processOptions,
+  );
+
+  return proc.runTurnExclusive(async () => {
+    const prepared = await prepareCodexAppServerChatTurn(params.messages);
+    const threadStartParams: Record<string, unknown> = {
+      model: params.model || undefined,
+      ephemeral: true,
+      approvalPolicy: "never",
+      sandbox: "read-only",
+      serviceName: "llm_for_zotero",
+      ...(prepared.developerInstructions
+        ? { developerInstructions: prepared.developerInstructions }
+        : {}),
+    };
+
+    let developerInstructionsAccepted = true;
+    let threadResponse: unknown;
+    try {
+      threadResponse = await proc.sendRequest(
+        "thread/start",
+        threadStartParams,
+      );
+    } catch (error) {
+      if (
+        !prepared.developerInstructions ||
+        !isCodexAppServerThreadStartInstructionsUnsupportedError(error)
+      ) {
+        throw error;
+      }
+      developerInstructionsAccepted = false;
+      const fallbackParams = { ...threadStartParams };
+      delete fallbackParams.developerInstructions;
+      threadResponse = await proc.sendRequest("thread/start", fallbackParams);
+    }
+
+    const threadId = extractCodexAppServerThreadId(threadResponse);
+    if (!threadId) {
+      throw new Error("Codex app-server did not return a thread ID");
+    }
+
+    const input = await resolveCodexAppServerTurnInputWithFallback({
+      proc,
+      threadId,
+      historyItemsToInject: prepared.historyItemsToInject,
+      turnInput: prepared.turnInput,
+      legacyInputFactory: () =>
+        buildLegacyCodexAppServerChatInput(params.messages, {
+          includeSystem: !developerInstructionsAccepted,
+        }),
+      logContext: "legacy Codex auth transport",
+    });
+    const turnResponse = await proc.sendRequest("turn/start", {
+      threadId,
+      input,
+      model: params.model || undefined,
+      approvalPolicy: "never",
+      sandboxPolicy: { type: "readOnly", networkAccess: false },
+      ...resolveCodexAppServerReasoningParams(params.reasoning, params.model),
+    });
+    const turnId = extractCodexAppServerTurnId(turnResponse);
+    if (!turnId) {
+      throw new Error("Codex app-server did not return a turn ID");
+    }
+
+    return waitForCodexAppServerTurnCompletion({
+      proc,
+      threadId,
+      turnId,
+      onTextDelta: params.onDelta,
+      onReasoning: params.onReasoning,
+      onUsage: params.onUsage,
+      signal: params.signal,
+      interruptOnAbort: true,
+      cacheKey: CODEX_SHARED_APP_SERVER_PROCESS_KEY,
+      processOptions,
+    });
+  });
+}

--- a/src/utils/codexAuthAppServerTransport.ts
+++ b/src/utils/codexAuthAppServerTransport.ts
@@ -17,6 +17,7 @@ import {
   resolveCodexAppServerReasoningParams,
   resolveCodexAppServerTurnInputWithFallback,
   waitForCodexAppServerTurnCompletion,
+  type CodexAppServerProcessOptions,
 } from "./codexAppServerProcess";
 import { prepareLegacyCodexIsolatedEnvironment } from "./codexAuthIsolation";
 
@@ -31,6 +32,7 @@ export type CodexTurnMcpServer = {
 // reliably disable a large user MCP catalog after the process has started.
 export const CODEX_SHARED_APP_SERVER_PROCESS_KEY =
   "codex_app_server_legacy_auth_isolated";
+export const CODEX_NATIVE_APP_SERVER_PROCESS_KEY = "codex_app_server_native";
 export const CODEX_LEGACY_APP_SERVER_CONFIG_OVERRIDES = [
   "mcp_servers={}",
   "skills.include_instructions=false",
@@ -38,7 +40,7 @@ export const CODEX_LEGACY_APP_SERVER_CONFIG_OVERRIDES = [
   "features.shell_snapshot=false",
 ];
 
-export async function runCodexAuthAppServerTurn(params: {
+type CodexAppServerSimpleTurnParams = {
   model: string;
   messages: ChatMessage[];
   reasoning?: ReasoningConfig;
@@ -49,23 +51,24 @@ export async function runCodexAuthAppServerTurn(params: {
   onUsage?: (usage: UsageStats) => void;
   /** Optional already-scoped MCP server exposed only to this isolated turn. */
   mcpServer?: CodexTurnMcpServer;
-}): Promise<string> {
-  const scopedMcp = params.mcpServer;
-  try {
-    const isolatedEnvironment =
-      await prepareLegacyCodexIsolatedEnvironment();
-    const processOptions = {
-      codexPath: resolveCodexAppServerBinaryPath(params.codexPath),
-      configOverrides: CODEX_LEGACY_APP_SERVER_CONFIG_OVERRIDES,
-      environment: isolatedEnvironment,
-    };
-    const proc = await getOrCreateCodexAppServerProcess(
-      CODEX_SHARED_APP_SERVER_PROCESS_KEY,
-      processOptions,
-    );
+};
 
-    return await proc.runTurnExclusive(async () => {
-      const prepared = await prepareCodexAppServerChatTurn(params.messages);
+async function runCodexAppServerSimpleTurn(
+  params: CodexAppServerSimpleTurnParams,
+  runtime: {
+    processKey: string;
+    processOptions: CodexAppServerProcessOptions;
+    logContext: string;
+  },
+): Promise<string> {
+  const scopedMcp = params.mcpServer;
+  const proc = await getOrCreateCodexAppServerProcess(
+    runtime.processKey,
+    runtime.processOptions,
+  );
+
+  return proc.runTurnExclusive(async () => {
+    const prepared = await prepareCodexAppServerChatTurn(params.messages);
     const threadStartParams: Record<string, unknown> = {
       model: params.model || undefined,
       ephemeral: true,
@@ -87,69 +90,106 @@ export async function runCodexAuthAppServerTurn(params: {
         : {}),
     };
 
-      let developerInstructionsAccepted = true;
-      let threadResponse: unknown;
-      try {
-        threadResponse = await proc.sendRequest(
-          "thread/start",
-          threadStartParams,
-        );
-      } catch (error) {
-        if (
-          !prepared.developerInstructions ||
-          !isCodexAppServerThreadStartInstructionsUnsupportedError(error)
-        ) {
-          throw error;
-        }
-        developerInstructionsAccepted = false;
-        const fallbackParams = { ...threadStartParams };
-        delete fallbackParams.developerInstructions;
-        threadResponse = await proc.sendRequest("thread/start", fallbackParams);
+    let developerInstructionsAccepted = true;
+    let threadResponse: unknown;
+    try {
+      threadResponse = await proc.sendRequest(
+        "thread/start",
+        threadStartParams,
+      );
+    } catch (error) {
+      if (
+        !prepared.developerInstructions ||
+        !isCodexAppServerThreadStartInstructionsUnsupportedError(error)
+      ) {
+        throw error;
       }
+      developerInstructionsAccepted = false;
+      const fallbackParams = { ...threadStartParams };
+      delete fallbackParams.developerInstructions;
+      threadResponse = await proc.sendRequest("thread/start", fallbackParams);
+    }
 
-      const threadId = extractCodexAppServerThreadId(threadResponse);
-      if (!threadId) {
-        throw new Error("Codex app-server did not return a thread ID");
-      }
+    const threadId = extractCodexAppServerThreadId(threadResponse);
+    if (!threadId) {
+      throw new Error("Codex app-server did not return a thread ID");
+    }
 
-      const input = await resolveCodexAppServerTurnInputWithFallback({
-        proc,
-        threadId,
-        historyItemsToInject: prepared.historyItemsToInject,
-        turnInput: prepared.turnInput,
-        legacyInputFactory: () =>
-          buildLegacyCodexAppServerChatInput(params.messages, {
-            includeSystem: !developerInstructionsAccepted,
-          }),
-        logContext: "legacy Codex auth transport",
-      });
-      const turnResponse = await proc.sendRequest("turn/start", {
-        threadId,
-        input,
-        model: params.model || undefined,
-        approvalPolicy: "never",
-        sandboxPolicy: { type: "readOnly", networkAccess: false },
-        ...resolveCodexAppServerReasoningParams(params.reasoning, params.model),
-      });
-      const turnId = extractCodexAppServerTurnId(turnResponse);
-      if (!turnId) {
-        throw new Error("Codex app-server did not return a turn ID");
-      }
+    const input = await resolveCodexAppServerTurnInputWithFallback({
+      proc,
+      threadId,
+      historyItemsToInject: prepared.historyItemsToInject,
+      turnInput: prepared.turnInput,
+      legacyInputFactory: () =>
+        buildLegacyCodexAppServerChatInput(params.messages, {
+          includeSystem: !developerInstructionsAccepted,
+        }),
+      logContext: runtime.logContext,
+    });
+    const turnResponse = await proc.sendRequest("turn/start", {
+      threadId,
+      input,
+      model: params.model || undefined,
+      approvalPolicy: "never",
+      sandboxPolicy: { type: "readOnly", networkAccess: false },
+      ...resolveCodexAppServerReasoningParams(params.reasoning, params.model),
+    });
+    const turnId = extractCodexAppServerTurnId(turnResponse);
+    if (!turnId) {
+      throw new Error("Codex app-server did not return a turn ID");
+    }
 
-      return waitForCodexAppServerTurnCompletion({
-        proc,
-        threadId,
-        turnId,
-        onTextDelta: params.onDelta,
-        onReasoning: params.onReasoning,
-        onUsage: params.onUsage,
-        signal: params.signal,
-        interruptOnAbort: true,
-        cacheKey: CODEX_SHARED_APP_SERVER_PROCESS_KEY,
-        processOptions,
-      });
+    return waitForCodexAppServerTurnCompletion({
+      proc,
+      threadId,
+      turnId,
+      onTextDelta: params.onDelta,
+      onReasoning: params.onReasoning,
+      onUsage: params.onUsage,
+      signal: params.signal,
+      interruptOnAbort: true,
+      cacheKey: runtime.processKey,
+      processOptions: runtime.processOptions,
+    });
+  });
+}
+
+export async function runCodexAuthAppServerTurn(
+  params: CodexAppServerSimpleTurnParams,
+): Promise<string> {
+  const scopedMcp = params.mcpServer;
+  try {
+    const isolatedEnvironment = await prepareLegacyCodexIsolatedEnvironment();
+    return await runCodexAppServerSimpleTurn(params, {
+      processKey: CODEX_SHARED_APP_SERVER_PROCESS_KEY,
+      processOptions: {
+        codexPath: resolveCodexAppServerBinaryPath(params.codexPath),
+        configOverrides: CODEX_LEGACY_APP_SERVER_CONFIG_OVERRIDES,
+        environment: isolatedEnvironment,
+      },
+      logContext: "legacy Codex auth transport",
     });
   } finally {
     scopedMcp?.clear?.();
   }
+}
+
+/**
+ * Runs a minimal ephemeral turn on the same unmodified process configuration
+ * used by native Codex conversations. This intentionally does not create the
+ * legacy isolated CODEX_HOME or suppress the user's Codex configuration.
+ */
+export async function runCodexNativeAppServerConnectionTurn(params: {
+  model: string;
+  messages: ChatMessage[];
+  signal?: AbortSignal;
+  codexPath?: string;
+}): Promise<string> {
+  return runCodexAppServerSimpleTurn(params, {
+    processKey: CODEX_NATIVE_APP_SERVER_PROCESS_KEY,
+    processOptions: {
+      codexPath: resolveCodexAppServerBinaryPath(params.codexPath),
+    },
+    logContext: "native Codex connection test",
+  });
 }

--- a/src/utils/codexAuthAppServerTransport.ts
+++ b/src/utils/codexAuthAppServerTransport.ts
@@ -18,12 +18,25 @@ import {
   resolveCodexAppServerTurnInputWithFallback,
   waitForCodexAppServerTurnCompletion,
 } from "./codexAppServerProcess";
+import { prepareLegacyCodexIsolatedEnvironment } from "./codexAuthIsolation";
 
-// Intentionally share the process used by the native Agent runtime. This lets
-// the legacy provider recover from Gecko fetch failures without launching a
-// second Codex runtime, and lets the Agent connection test warm the same
-// process used by real turns.
-export const CODEX_SHARED_APP_SERVER_PROCESS_KEY = "codex_app_server_native";
+export type CodexTurnMcpServer = {
+  serverName: string;
+  configValue: Record<string, unknown>;
+  clear?: () => void;
+};
+
+// Legacy retries run in a separate app-server whose global MCP table is empty.
+// Thread-level overrides are merged with global config by Codex, so they cannot
+// reliably disable a large user MCP catalog after the process has started.
+export const CODEX_SHARED_APP_SERVER_PROCESS_KEY =
+  "codex_app_server_legacy_auth_isolated";
+export const CODEX_LEGACY_APP_SERVER_CONFIG_OVERRIDES = [
+  "mcp_servers={}",
+  "skills.include_instructions=false",
+  "skills.bundled.enabled=false",
+  "features.shell_snapshot=false",
+];
 
 export async function runCodexAuthAppServerTurn(params: {
   model: string;
@@ -34,17 +47,25 @@ export async function runCodexAuthAppServerTurn(params: {
   onDelta?: (delta: string) => void;
   onReasoning?: (event: ReasoningEvent) => void;
   onUsage?: (usage: UsageStats) => void;
+  /** Optional already-scoped MCP server exposed only to this isolated turn. */
+  mcpServer?: CodexTurnMcpServer;
 }): Promise<string> {
-  const processOptions = {
-    codexPath: resolveCodexAppServerBinaryPath(params.codexPath),
-  };
-  const proc = await getOrCreateCodexAppServerProcess(
-    CODEX_SHARED_APP_SERVER_PROCESS_KEY,
-    processOptions,
-  );
+  const scopedMcp = params.mcpServer;
+  try {
+    const isolatedEnvironment =
+      await prepareLegacyCodexIsolatedEnvironment();
+    const processOptions = {
+      codexPath: resolveCodexAppServerBinaryPath(params.codexPath),
+      configOverrides: CODEX_LEGACY_APP_SERVER_CONFIG_OVERRIDES,
+      environment: isolatedEnvironment,
+    };
+    const proc = await getOrCreateCodexAppServerProcess(
+      CODEX_SHARED_APP_SERVER_PROCESS_KEY,
+      processOptions,
+    );
 
-  return proc.runTurnExclusive(async () => {
-    const prepared = await prepareCodexAppServerChatTurn(params.messages);
+    return await proc.runTurnExclusive(async () => {
+      const prepared = await prepareCodexAppServerChatTurn(params.messages);
     const threadStartParams: Record<string, unknown> = {
       model: params.model || undefined,
       ephemeral: true,
@@ -54,68 +75,81 @@ export async function runCodexAuthAppServerTurn(params: {
       ...(prepared.developerInstructions
         ? { developerInstructions: prepared.developerInstructions }
         : {}),
+      ...(scopedMcp
+        ? {
+            config: {
+              features: { shell_tool: false },
+              mcp_servers: {
+                [scopedMcp.serverName]: scopedMcp.configValue,
+              },
+            },
+          }
+        : {}),
     };
 
-    let developerInstructionsAccepted = true;
-    let threadResponse: unknown;
-    try {
-      threadResponse = await proc.sendRequest(
-        "thread/start",
-        threadStartParams,
-      );
-    } catch (error) {
-      if (
-        !prepared.developerInstructions ||
-        !isCodexAppServerThreadStartInstructionsUnsupportedError(error)
-      ) {
-        throw error;
+      let developerInstructionsAccepted = true;
+      let threadResponse: unknown;
+      try {
+        threadResponse = await proc.sendRequest(
+          "thread/start",
+          threadStartParams,
+        );
+      } catch (error) {
+        if (
+          !prepared.developerInstructions ||
+          !isCodexAppServerThreadStartInstructionsUnsupportedError(error)
+        ) {
+          throw error;
+        }
+        developerInstructionsAccepted = false;
+        const fallbackParams = { ...threadStartParams };
+        delete fallbackParams.developerInstructions;
+        threadResponse = await proc.sendRequest("thread/start", fallbackParams);
       }
-      developerInstructionsAccepted = false;
-      const fallbackParams = { ...threadStartParams };
-      delete fallbackParams.developerInstructions;
-      threadResponse = await proc.sendRequest("thread/start", fallbackParams);
-    }
 
-    const threadId = extractCodexAppServerThreadId(threadResponse);
-    if (!threadId) {
-      throw new Error("Codex app-server did not return a thread ID");
-    }
+      const threadId = extractCodexAppServerThreadId(threadResponse);
+      if (!threadId) {
+        throw new Error("Codex app-server did not return a thread ID");
+      }
 
-    const input = await resolveCodexAppServerTurnInputWithFallback({
-      proc,
-      threadId,
-      historyItemsToInject: prepared.historyItemsToInject,
-      turnInput: prepared.turnInput,
-      legacyInputFactory: () =>
-        buildLegacyCodexAppServerChatInput(params.messages, {
-          includeSystem: !developerInstructionsAccepted,
-        }),
-      logContext: "legacy Codex auth transport",
-    });
-    const turnResponse = await proc.sendRequest("turn/start", {
-      threadId,
-      input,
-      model: params.model || undefined,
-      approvalPolicy: "never",
-      sandboxPolicy: { type: "readOnly", networkAccess: false },
-      ...resolveCodexAppServerReasoningParams(params.reasoning, params.model),
-    });
-    const turnId = extractCodexAppServerTurnId(turnResponse);
-    if (!turnId) {
-      throw new Error("Codex app-server did not return a turn ID");
-    }
+      const input = await resolveCodexAppServerTurnInputWithFallback({
+        proc,
+        threadId,
+        historyItemsToInject: prepared.historyItemsToInject,
+        turnInput: prepared.turnInput,
+        legacyInputFactory: () =>
+          buildLegacyCodexAppServerChatInput(params.messages, {
+            includeSystem: !developerInstructionsAccepted,
+          }),
+        logContext: "legacy Codex auth transport",
+      });
+      const turnResponse = await proc.sendRequest("turn/start", {
+        threadId,
+        input,
+        model: params.model || undefined,
+        approvalPolicy: "never",
+        sandboxPolicy: { type: "readOnly", networkAccess: false },
+        ...resolveCodexAppServerReasoningParams(params.reasoning, params.model),
+      });
+      const turnId = extractCodexAppServerTurnId(turnResponse);
+      if (!turnId) {
+        throw new Error("Codex app-server did not return a turn ID");
+      }
 
-    return waitForCodexAppServerTurnCompletion({
-      proc,
-      threadId,
-      turnId,
-      onTextDelta: params.onDelta,
-      onReasoning: params.onReasoning,
-      onUsage: params.onUsage,
-      signal: params.signal,
-      interruptOnAbort: true,
-      cacheKey: CODEX_SHARED_APP_SERVER_PROCESS_KEY,
-      processOptions,
+      return waitForCodexAppServerTurnCompletion({
+        proc,
+        threadId,
+        turnId,
+        onTextDelta: params.onDelta,
+        onReasoning: params.onReasoning,
+        onUsage: params.onUsage,
+        signal: params.signal,
+        interruptOnAbort: true,
+        cacheKey: CODEX_SHARED_APP_SERVER_PROCESS_KEY,
+        processOptions,
+      });
     });
-  });
+  } finally {
+    scopedMcp?.clear?.();
+  }
 }

--- a/src/utils/codexAuthIsolation.ts
+++ b/src/utils/codexAuthIsolation.ts
@@ -1,0 +1,189 @@
+import { CodexAppServerProcess } from "./codexAppServerProcess";
+import { getRuntimePlatformInfo } from "./runtimePlatform";
+
+type IOUtilsLike = {
+  exists?: (path: string) => Promise<boolean>;
+  makeDirectory?: (
+    path: string,
+    options?: { createAncestors?: boolean; ignoreExisting?: boolean },
+  ) => Promise<void>;
+  read?: (path: string) => Promise<Uint8Array>;
+  remove?: (path: string, options?: { ignoreAbsent?: boolean }) => Promise<void>;
+};
+
+type PathUtilsLike = {
+  homeDir?: string;
+  join?: (...parts: string[]) => string;
+};
+
+const LEGACY_CODEX_HOME_DIR = ".llm-for-zotero-legacy";
+
+function getIOUtils(): IOUtilsLike {
+  const io =
+    (globalThis as { IOUtils?: IOUtilsLike }).IOUtils ||
+    (ztoolkit.getGlobal("IOUtils") as IOUtilsLike | undefined);
+  if (!io?.exists || !io.makeDirectory || !io.read || !io.remove) {
+    throw new Error("IOUtils is unavailable for isolated Codex auth setup");
+  }
+  return io;
+}
+
+function getPathUtils(): PathUtilsLike {
+  return (
+    (globalThis as { PathUtils?: PathUtilsLike }).PathUtils ||
+    (ztoolkit.getGlobal("PathUtils") as PathUtilsLike | undefined) ||
+    {}
+  );
+}
+
+function getProcessEnvironment(): Record<string, string | undefined> {
+  const direct = (
+    globalThis as {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env;
+  const toolkit = (
+    ztoolkit.getGlobal("process") as
+      | { env?: Record<string, string | undefined> }
+      | undefined
+  )?.env;
+  const env: Record<string, string | undefined> = {
+    ...(toolkit || {}),
+    ...(direct || {}),
+  };
+  const services = (
+    globalThis as {
+      Services?: { env?: { get?: (name: string) => string | undefined } };
+    }
+  ).Services;
+  for (const key of ["CODEX_HOME", "HOME", "USERPROFILE"]) {
+    try {
+      const value = services?.env?.get?.(key);
+      if (typeof value === "string" && value.trim()) {
+        env[key] = value.trim();
+      }
+    } catch {
+      /* ignore unavailable environment entries */
+    }
+  }
+  return env;
+}
+
+function joinLocalPath(...parts: string[]): string {
+  const pathUtils = getPathUtils();
+  if (pathUtils.join) return pathUtils.join(...parts);
+  const separator = getRuntimePlatformInfo().pathSeparator;
+  return parts
+    .filter(Boolean)
+    .map((part, index) =>
+      index === 0
+        ? part.replace(/[\\/]+$/, "")
+        : part.replace(/^[\\/]+|[\\/]+$/g, ""),
+    )
+    .join(separator);
+}
+
+function resolvePrimaryCodexHome(): string {
+  const env = getProcessEnvironment();
+  const configured = env.CODEX_HOME?.trim();
+  if (configured) return configured;
+  const home =
+    env.HOME?.trim() ||
+    env.USERPROFILE?.trim() ||
+    getPathUtils().homeDir?.trim();
+  if (!home) {
+    throw new Error("Unable to resolve the primary Codex home directory");
+  }
+  return joinLocalPath(home, ".codex");
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  for (let index = 0; index < left.byteLength; index++) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+async function waitForProcess(proc: any): Promise<number | undefined> {
+  const result = await proc.wait();
+  if (typeof result === "number") return result;
+  if (typeof result?.exitCode === "number") return result.exitCode;
+  return undefined;
+}
+
+async function createAuthHardLink(params: {
+  sourcePath: string;
+  destinationPath: string;
+}): Promise<void> {
+  const info = getRuntimePlatformInfo();
+  const Subprocess = await CodexAppServerProcess.loadSubprocessModule();
+  const invocation =
+    info.platform === "windows"
+      ? {
+          command: info.shellPath,
+          arguments: [
+            "/d",
+            "/c",
+            "mklink",
+            "/H",
+            params.destinationPath,
+            params.sourcePath,
+          ],
+        }
+      : {
+          command: "/bin/ln",
+          arguments: [params.sourcePath, params.destinationPath],
+        };
+  const proc = await Subprocess.call(invocation);
+  const exitCode = await waitForProcess(proc);
+  if (exitCode !== undefined && exitCode !== 0) {
+    throw new Error(`Unable to create isolated Codex auth link (${exitCode})`);
+  }
+}
+
+/**
+ * Returns a minimal CODEX_HOME that shares only the real login file.
+ *
+ * A hard link is intentional: Codex refreshes auth.json in place, so both the
+ * regular CLI and the isolated legacy transport continue to observe the same
+ * credentials without copying tokens into a second independently refreshed
+ * file. Config, skills, plugins, and MCP servers remain isolated.
+ */
+export async function prepareLegacyCodexIsolatedEnvironment(): Promise<
+  Record<string, string>
+> {
+  const io = getIOUtils();
+  const primaryHome = resolvePrimaryCodexHome();
+  const sourceAuthPath = joinLocalPath(primaryHome, "auth.json");
+  if (!(await io.exists!(sourceAuthPath))) {
+    throw new Error(
+      "Codex auth token not found. Run `codex login` before using the legacy Codex provider.",
+    );
+  }
+
+  const isolatedHome = joinLocalPath(primaryHome, LEGACY_CODEX_HOME_DIR);
+  await io.makeDirectory!(isolatedHome, {
+    createAncestors: true,
+    ignoreExisting: true,
+  });
+  const isolatedAuthPath = joinLocalPath(isolatedHome, "auth.json");
+
+  if (await io.exists!(isolatedAuthPath)) {
+    const [sourceBytes, isolatedBytes] = await Promise.all([
+      io.read!(sourceAuthPath),
+      io.read!(isolatedAuthPath),
+    ]);
+    if (!bytesEqual(sourceBytes, isolatedBytes)) {
+      await io.remove!(isolatedAuthPath, { ignoreAbsent: true });
+    }
+  }
+  if (!(await io.exists!(isolatedAuthPath))) {
+    await createAuthHardLink({
+      sourcePath: sourceAuthPath,
+      destinationPath: isolatedAuthPath,
+    });
+  }
+
+  return { CODEX_HOME: isolatedHome };
+}

--- a/src/utils/codexTransportError.ts
+++ b/src/utils/codexTransportError.ts
@@ -1,0 +1,10 @@
+export function isCodexFetchTransportError(error: unknown): boolean {
+  const name = error instanceof Error ? error.name : "";
+  const message = error instanceof Error ? error.message : String(error || "");
+  return (
+    name === "TypeError" &&
+    /networkerror|failed to fetch|fetch resource|network request failed/i.test(
+      message,
+    )
+  );
+}

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -484,14 +484,14 @@ const zhCN: Record<string, string> = {
     '选择上方的预设，或切换到"自定义"以手动输入完整的基础 URL 或端点。',
   "codex auth usually uses https://chatgpt.com/backend-api/codex/responses":
     "codex 认证通常使用 https://chatgpt.com/backend-api/codex/responses",
-  "Legacy direct ChatGPT/Codex backend mode. Existing users can keep using it in this release. New users should use Codex App Server. Planned for deprecation in a future release after app-server validation.":
-    "旧版的 ChatGPT/Codex 直连后端模式。当前用户在此版本中可以继续使用，但新用户应改用 Codex App Server。待 app-server 验证稳定后，会在未来版本中计划弃用。",
+  "Compatibility mode for existing Codex-auth provider entries. Requests reuse the local Codex app-server runtime to avoid Zotero network transport failures.":
+    "现有 Codex 认证服务商条目的兼容模式。请求会复用本地 Codex app-server 运行时，以避开 Zotero 的网络传输故障。",
   "Recommended official Codex integration. Runs the local `codex app-server` CLI as the native Codex runtime. Run `codex login` first.":
     "推荐的官方 Codex 集成方式。它会将本地 `codex app-server` CLI 作为原生 Codex 运行时。请先运行 `codex login`。",
   "Codex App Server (native runtime settings)":
     "Codex App Server（原生运行时设置）",
-  "Legacy direct backend URL. Usually uses https://chatgpt.com/backend-api/codex/responses. Existing users can keep it in this release, but new users should use Codex App Server. Planned for deprecation in a future release after app-server validation.":
-    "旧版直连后端 URL，通常使用 https://chatgpt.com/backend-api/codex/responses。当前用户在此版本中可以继续使用，但新用户应改用 Codex App Server。待 app-server 验证稳定后，会在未来版本中计划弃用。",
+  "Kept for legacy configuration compatibility. Codex-auth requests are sent through the local Codex app-server runtime.":
+    "仅为兼容旧配置而保留。Codex 认证请求会通过本地 Codex app-server 运行时发送。",
   "Uses Codex responses with the local codex app-server transport.":
     "通过本地 codex app-server 传输使用 Codex responses。",
   "Uses Codex responses with the legacy direct backend transport.":
@@ -569,6 +569,8 @@ const zhCN: Record<string, string> = {
     "无法加载 Codex 模型。仅显示当前模型。",
   "Retry loading Codex models": "重试加载 Codex 模型",
   "Codex did not return any available models.": "Codex 未返回任何可用模型。",
+  'The installed Codex CLI does not list "%model%". Available models: %models%.':
+    "已安装的 Codex CLI 未列出“%model%”。可用模型：%models%。",
   "Fetch Models": "获取模型",
   WebChat: "WebChat",
   "Provider A": "服务商 A",

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -484,14 +484,14 @@ const zhCN: Record<string, string> = {
     '选择上方的预设，或切换到"自定义"以手动输入完整的基础 URL 或端点。',
   "codex auth usually uses https://chatgpt.com/backend-api/codex/responses":
     "codex 认证通常使用 https://chatgpt.com/backend-api/codex/responses",
-  "Compatibility mode for existing Codex-auth provider entries. Requests reuse the local Codex app-server runtime to avoid Zotero network transport failures.":
-    "现有 Codex 认证服务商条目的兼容模式。请求会复用本地 Codex app-server 运行时，以避开 Zotero 的网络传输故障。",
+  "Compatibility mode for existing Codex-auth provider entries. Requests use the configured legacy endpoint first, then retry through an isolated local Codex app-server only when Zotero's network transport fails.":
+    "现有 Codex 认证服务商条目的兼容模式。请求会先使用已配置的旧版端点；只有 Zotero 网络传输失败时，才会通过隔离的本地 Codex app-server 重试。",
   "Recommended official Codex integration. Runs the local `codex app-server` CLI as the native Codex runtime. Run `codex login` first.":
     "推荐的官方 Codex 集成方式。它会将本地 `codex app-server` CLI 作为原生 Codex 运行时。请先运行 `codex login`。",
   "Codex App Server (native runtime settings)":
     "Codex App Server（原生运行时设置）",
-  "Kept for legacy configuration compatibility. Codex-auth requests are sent through the local Codex app-server runtime.":
-    "仅为兼容旧配置而保留。Codex 认证请求会通过本地 Codex app-server 运行时发送。",
+  "Kept for legacy configuration compatibility. This endpoint is tried first; Zotero network transport failures retry through an isolated local Codex app-server.":
+    "仅为兼容旧配置而保留。系统会先尝试此端点；若 Zotero 网络传输失败，则通过隔离的本地 Codex app-server 重试。",
   "Uses Codex responses with the local codex app-server transport.":
     "通过本地 codex app-server 传输使用 Codex responses。",
   "Uses Codex responses with the legacy direct backend transport.":

--- a/src/utils/llmClient.ts
+++ b/src/utils/llmClient.ts
@@ -106,6 +106,7 @@ import {
   ensureModelCapabilities,
   getModelCapabilities,
 } from "../modelCapabilities";
+import { runCodexAuthAppServerTurn } from "./codexAuthAppServerTransport";
 
 // =============================================================================
 // Types
@@ -446,6 +447,7 @@ type OSLike = {
 type CodexTokenData = {
   access_token?: string;
   refresh_token?: string;
+  account_id?: string;
 };
 
 type CodexAuthJson = {
@@ -669,6 +671,11 @@ function extractCodexRefreshToken(auth: CodexAuthJson | null): string {
   return typeof token === "string" ? token.trim() : "";
 }
 
+function extractCodexAccountId(auth: CodexAuthJson | null): string {
+  const accountId = auth?.tokens?.account_id;
+  return typeof accountId === "string" ? accountId.trim() : "";
+}
+
 async function refreshCodexAccessToken(params: {
   authPath: string;
   refreshToken: string;
@@ -725,13 +732,19 @@ async function refreshCodexAccessToken(params: {
 
 async function resolveCodexAccessToken(params?: {
   signal?: AbortSignal;
-}): Promise<{ token: string; refreshToken: string; authPath: string }> {
+}): Promise<{
+  token: string;
+  refreshToken: string;
+  authPath: string;
+  accountId: string;
+}> {
   const authPath = resolveCodexAuthPath();
   const auth = await loadCodexAuthJson(authPath);
   const accessToken = extractCodexAccessToken(auth);
   const refreshToken = extractCodexRefreshToken(auth);
+  const accountId = extractCodexAccountId(auth);
   if (accessToken) {
-    return { token: accessToken, refreshToken, authPath };
+    return { token: accessToken, refreshToken, authPath, accountId };
   }
   if (refreshToken) {
     const refreshed = await refreshCodexAccessToken({
@@ -739,7 +752,7 @@ async function resolveCodexAccessToken(params?: {
       refreshToken,
       signal: params?.signal,
     });
-    return { token: refreshed, refreshToken, authPath };
+    return { token: refreshed, refreshToken, authPath, accountId };
   }
   throw new Error(
     "codex auth token not found. Please run `codex login` and ensure ~/.codex/auth.json is available.",
@@ -2676,6 +2689,17 @@ function assertCodexAppServerUsesNativeRuntime(
   );
 }
 
+function isCodexFetchTransportError(error: unknown): boolean {
+  const name = error instanceof Error ? error.name : "";
+  const message = error instanceof Error ? error.message : String(error || "");
+  return (
+    name === "TypeError" &&
+    /networkerror|failed to fetch|fetch resource|network request failed/i.test(
+      message,
+    )
+  );
+}
+
 /**
  * Gemini marks thought-summary parts with `thought: true` when
  * `includeThoughts` is requested.  A `thoughtSignature` alone does NOT make a
@@ -2972,6 +2996,7 @@ export type RequestAuthState = {
   codex?: {
     authPath: string;
     refreshToken: string;
+    accountId: string;
   };
   copilot?: {
     githubToken: string;
@@ -2981,6 +3006,7 @@ export type RequestAuthState = {
 function buildAuthHeaders(
   token: string,
   mode?: ModelProviderAuthMode,
+  codexAccountId?: string,
 ): Record<string, string> {
   if (mode === "copilot_auth") {
     return buildCopilotHeaders(token);
@@ -2990,6 +3016,12 @@ function buildAuthHeaders(
   };
   if (token) {
     headers.Authorization = `Bearer ${token}`;
+  }
+  if (mode === "codex_auth") {
+    if (codexAccountId) {
+      headers["ChatGPT-Account-ID"] = codexAccountId;
+    }
+    headers.Originator = "codex";
   }
   return headers;
 }
@@ -3013,12 +3045,14 @@ async function refreshCodexAuthState(
     refreshToken,
     signal,
   });
+  const refreshedAuth = await loadCodexAuthJson(authPath);
   return {
     mode: "codex_auth",
     token,
     codex: {
       authPath,
       refreshToken,
+      accountId: extractCodexAccountId(refreshedAuth),
     },
   };
 }
@@ -3057,7 +3091,9 @@ async function postWithTemperatureFallback(params: {
   const send = (bodyPayload: Record<string, unknown>, auth: RequestAuthState) =>
     getFetch()(params.url, {
       method: "POST",
-      headers: params.headers ?? buildAuthHeaders(auth.token, auth.mode),
+      headers:
+        params.headers ??
+        buildAuthHeaders(auth.token, auth.mode, auth.codex?.accountId),
       body: JSON.stringify(bodyPayload),
       signal: params.signal,
     });
@@ -3295,6 +3331,7 @@ export async function resolveRequestAuthState(params: {
       codex: {
         authPath: resolved.authPath,
         refreshToken: resolved.refreshToken,
+        accountId: resolved.accountId,
       },
     };
   }
@@ -3640,104 +3677,125 @@ export async function callLLMStream(
     });
   }
   assertCodexAppServerUsesNativeRuntime(authMode);
-  const auth = await resolveRequestAuthState({
-    authMode,
-    apiKey,
-    signal: params.signal,
-  });
-  if (inputCap.capped) {
-    ztoolkit.log("LLM: Applied model-aware input cap", {
+  if (authMode === "codex_auth") {
+    if (Array.isArray(params.attachments) && params.attachments.length) {
+      throw new Error(
+        "codex auth currently does not support file attachments in this plugin v1.",
+      );
+    }
+  }
+  try {
+    const auth = await resolveRequestAuthState({
+      authMode,
+      apiKey,
+      signal: params.signal,
+    });
+    if (inputCap.capped) {
+      ztoolkit.log("LLM: Applied model-aware input cap", {
+        model,
+        beforeTokens: inputCap.estimatedBeforeTokens,
+        afterTokens: inputCap.estimatedAfterTokens,
+        capTokens: inputCap.limitTokens,
+        softCapTokens: inputCap.softLimitTokens,
+        effects: inputCap.effects,
+      });
+    }
+    const useResponses =
+      providerProtocol === "responses_api" ||
+      providerProtocol === "codex_responses";
+    // Only upload files via /v1/files for providers that actually host that endpoint.
+    // Third-party relays using responses_api get inline base64 instead (via buildResponsesInput).
+    const canUploadFiles =
+      useResponses && providerSupportsResponsesEndpoint(apiBase);
+    const responseFileIds = canUploadFiles
+      ? await uploadFilesForResponses({
+          apiBase,
+          apiKey: auth.token,
+          attachments: params.attachments,
+          signal: params.signal,
+        })
+      : [];
+    const effectiveTemperature = normalizeTemperature(params.temperature);
+    const effectiveMaxTokens = normalizeMaxTokensForRequest({
+      value: params.maxTokens,
       model,
-      beforeTokens: inputCap.estimatedBeforeTokens,
-      afterTokens: inputCap.estimatedAfterTokens,
-      capTokens: inputCap.limitTokens,
-      softCapTokens: inputCap.softLimitTokens,
-      effects: inputCap.effects,
+      apiBase,
+      protocol: providerProtocol,
+      authMode,
+    });
+
+    const url = resolveProviderTransportEndpoint({
+      protocol: providerProtocol,
+      apiBase,
+      model,
+      stream: true,
+      authMode,
+    });
+    const requestHeaders =
+      authMode === "codex_auth"
+        ? undefined
+        : buildProviderTransportHeaders({
+            protocol: providerProtocol,
+            apiKey: auth.token,
+            authMode,
+          });
+    const buildPayload = createChatPayloadBuilder({
+      model,
+      messages,
+      useResponses,
+      responseFileIds,
+      authMode,
+      apiBase,
+      providerProtocol,
+      effectiveTemperature,
+      effectiveMaxTokens,
+      stream: true,
+      contextCache: params.contextCache,
+    });
+    const res = await postWithReasoningFallback({
+      url,
+      auth,
+      headers: requestHeaders,
+      modelName: model,
+      initialReasoning: params.reasoning,
+      buildPayload,
+      signal: params.signal,
+    });
+
+    // Fallback to non-streaming if body is not available
+    if (!res.body) {
+      if (useResponses) {
+        const data = (await res.json()) as {
+          output_text?: string;
+          output?: Array<{ content?: Array<{ type?: string; text?: string }> }>;
+        };
+        return extractResponsesOutputText(data);
+      }
+      return callLLM(params);
+    }
+
+    return useResponses
+      ? parseResponsesStream(res.body, onDelta, onReasoning, onUsage)
+      : parseStreamResponse(res.body, onDelta, onReasoning, onUsage);
+  } catch (error) {
+    if (authMode !== "codex_auth" || !isCodexFetchTransportError(error)) {
+      throw error;
+    }
+    ztoolkit.log(
+      "LLM: Zotero fetch failed for Codex auth; retrying through local app-server",
+      error,
+    );
+    return runCodexAuthAppServerTurn({
+      model,
+      messages,
+      reasoning: params.reasoning,
+      signal: params.signal,
+      codexPath: (getPref("codexAppServerPath") || "").toString().trim(),
+      onDelta,
+      onReasoning,
+      onUsage,
     });
   }
-  if (
-    authMode === "codex_auth" &&
-    Array.isArray(params.attachments) &&
-    params.attachments.length
-  ) {
-    throw new Error(
-      "codex auth currently does not support file attachments in this plugin v1.",
-    );
-  }
-  const useResponses =
-    providerProtocol === "responses_api" ||
-    providerProtocol === "codex_responses";
-  // Only upload files via /v1/files for providers that actually host that endpoint.
-  // Third-party relays using responses_api get inline base64 instead (via buildResponsesInput).
-  const canUploadFiles =
-    useResponses && providerSupportsResponsesEndpoint(apiBase);
-  const responseFileIds = canUploadFiles
-    ? await uploadFilesForResponses({
-        apiBase,
-        apiKey: auth.token,
-        attachments: params.attachments,
-        signal: params.signal,
-      })
-    : [];
-  const effectiveTemperature = normalizeTemperature(params.temperature);
-  const effectiveMaxTokens = normalizeMaxTokensForRequest({
-    value: params.maxTokens,
-    model,
-    apiBase,
-    protocol: providerProtocol,
-    authMode,
-  });
-
-  const url = resolveProviderTransportEndpoint({
-    protocol: providerProtocol,
-    apiBase,
-    model,
-    stream: true,
-    authMode,
-  });
-  const requestHeaders = buildProviderTransportHeaders({
-    protocol: providerProtocol,
-    apiKey: auth.token,
-    authMode,
-  });
-  const buildPayload = createChatPayloadBuilder({
-    model,
-    messages,
-    useResponses,
-    responseFileIds,
-    authMode,
-    apiBase,
-    providerProtocol,
-    effectiveTemperature,
-    effectiveMaxTokens,
-    stream: true,
-    contextCache: params.contextCache,
-  });
-  const res = await postWithReasoningFallback({
-    url,
-    auth,
-    headers: requestHeaders,
-    modelName: model,
-    initialReasoning: params.reasoning,
-    buildPayload,
-    signal: params.signal,
-  });
-
-  // Fallback to non-streaming if body is not available
-  if (!res.body) {
-    if (useResponses) {
-      const data = (await res.json()) as {
-        output_text?: string;
-        output?: Array<{ content?: Array<{ type?: string; text?: string }> }>;
-      };
-      return extractResponsesOutputText(data);
-    }
-    return callLLM(params);
-  }
-
-  return useResponses
-    ? parseResponsesStream(res.body, onDelta, onReasoning, onUsage)
-    : parseStreamResponse(res.body, onDelta, onReasoning, onUsage);
 }
 
 /**

--- a/src/utils/llmClient.ts
+++ b/src/utils/llmClient.ts
@@ -2689,7 +2689,7 @@ function assertCodexAppServerUsesNativeRuntime(
   );
 }
 
-function isCodexFetchTransportError(error: unknown): boolean {
+export function isCodexFetchTransportError(error: unknown): boolean {
   const name = error instanceof Error ? error.name : "";
   const message = error instanceof Error ? error.message : String(error || "");
   return (

--- a/src/utils/llmClient.ts
+++ b/src/utils/llmClient.ts
@@ -107,6 +107,8 @@ import {
   getModelCapabilities,
 } from "../modelCapabilities";
 import { runCodexAuthAppServerTurn } from "./codexAuthAppServerTransport";
+import { isCodexFetchTransportError } from "./codexTransportError";
+export { isCodexFetchTransportError } from "./codexTransportError";
 
 // =============================================================================
 // Types
@@ -2689,17 +2691,6 @@ function assertCodexAppServerUsesNativeRuntime(
   );
 }
 
-export function isCodexFetchTransportError(error: unknown): boolean {
-  const name = error instanceof Error ? error.name : "";
-  const message = error instanceof Error ? error.message : String(error || "");
-  return (
-    name === "TypeError" &&
-    /networkerror|failed to fetch|fetch resource|network request failed/i.test(
-      message,
-    )
-  );
-}
-
 /**
  * Gemini marks thought-summary parts with `thought: true` when
  * `includeThoughts` is requested.  A `thoughtSignature` alone does NOT make a
@@ -3591,6 +3582,7 @@ export async function callLLM(params: ChatParams): Promise<string> {
     protocol: providerProtocol,
     apiKey: auth.token,
     authMode,
+    codexAccountId: auth.codex?.accountId,
   });
   const buildPayload = createChatPayloadBuilder({
     model,

--- a/src/utils/providerConnectionTest.ts
+++ b/src/utils/providerConnectionTest.ts
@@ -11,7 +11,18 @@ import {
 } from "./providerTransport";
 import { createAgentModelAdapter } from "../agent/model/factory";
 import type { AgentRuntimeRequest } from "../agent/types";
-import { runCodexAuthAppServerTurn } from "./codexAuthAppServerTransport";
+import type { ChatMessage } from "../shared/llm";
+import {
+  runCodexAuthAppServerTurn,
+  runCodexNativeAppServerConnectionTurn,
+} from "./codexAuthAppServerTransport";
+import { isCodexFetchTransportError } from "./codexTransportError";
+
+type CodexConnectionTurn = (params: {
+  model: string;
+  messages: ChatMessage[];
+  codexPath?: string;
+}) => Promise<string>;
 
 function extractTextFromCodexSSE(raw: string): string {
   const lines = raw.split(/\r?\n/);
@@ -230,18 +241,21 @@ export function getProviderConnectionCapabilityLabel(params: {
 export async function runCodexAppServerConnectionTest(params: {
   modelName: string;
   codexPath?: string;
+  runTurn?: CodexConnectionTurn;
 }): Promise<{ reply: string; capabilityLabel: string }> {
-  const reply = await runCodexAuthAppServerTurn({
-    model: params.modelName,
-    codexPath: params.codexPath,
-    messages: [
-      {
-        role: "system",
-        content: "You are a concise assistant. Reply with OK.",
-      },
-      { role: "user", content: "Say OK" },
-    ],
-  });
+  const reply = await (params.runTurn || runCodexNativeAppServerConnectionTurn)(
+    {
+      model: params.modelName,
+      codexPath: params.codexPath,
+      messages: [
+        {
+          role: "system",
+          content: "You are a concise assistant. Reply with OK.",
+        },
+        { role: "user", content: "Say OK" },
+      ],
+    },
+  );
 
   const request = {
     conversationKey: 0,
@@ -268,9 +282,40 @@ export async function runProviderConnectionTest(params: {
   apiBase: string;
   apiKey: string;
   modelName: string;
+  codexAccountId?: string;
+  runCodexFallback?: CodexConnectionTurn;
 }): Promise<{ reply: string; capabilityLabel: string }> {
-  if (params.authMode === "codex_auth") {
-    const reply = await runCodexAuthAppServerTurn({
+  const { body, expectsSse } = buildConnectionRequestPayload({
+    protocol: params.protocol,
+    modelName: params.modelName,
+  });
+  const url = resolveProviderTransportEndpoint({
+    protocol: params.protocol,
+    apiBase: params.apiBase,
+    model: params.modelName,
+    stream: expectsSse,
+    authMode: params.authMode,
+  });
+  let response: Response;
+  try {
+    response = await params.fetchFn(url, {
+      method: "POST",
+      headers: buildProviderTransportHeaders({
+        protocol: params.protocol,
+        apiKey: params.apiKey,
+        authMode: params.authMode,
+        codexAccountId: params.codexAccountId,
+      }),
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    if (
+      params.authMode !== "codex_auth" ||
+      !isCodexFetchTransportError(error)
+    ) {
+      throw error;
+    }
+    const reply = await (params.runCodexFallback || runCodexAuthAppServerTurn)({
       model: params.modelName,
       messages: [
         {
@@ -285,26 +330,6 @@ export async function runProviderConnectionTest(params: {
       capabilityLabel: getProviderConnectionCapabilityLabel(params),
     };
   }
-  const { body, expectsSse } = buildConnectionRequestPayload({
-    protocol: params.protocol,
-    modelName: params.modelName,
-  });
-  const url = resolveProviderTransportEndpoint({
-    protocol: params.protocol,
-    apiBase: params.apiBase,
-    model: params.modelName,
-    stream: expectsSse,
-    authMode: params.authMode,
-  });
-  const response = await params.fetchFn(url, {
-    method: "POST",
-    headers: buildProviderTransportHeaders({
-      protocol: params.protocol,
-      apiKey: params.apiKey,
-      authMode: params.authMode,
-    }),
-    body: JSON.stringify(body),
-  });
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}: ${await response.text()}`);
   }

--- a/src/utils/providerConnectionTest.ts
+++ b/src/utils/providerConnectionTest.ts
@@ -11,14 +11,7 @@ import {
 } from "./providerTransport";
 import { createAgentModelAdapter } from "../agent/model/factory";
 import type { AgentRuntimeRequest } from "../agent/types";
-import {
-  destroyCachedCodexAppServerProcess,
-  extractCodexAppServerThreadId,
-  extractCodexAppServerTurnId,
-  getOrCreateCodexAppServerProcess,
-  resolveCodexAppServerBinaryPath,
-  waitForCodexAppServerTurnCompletion,
-} from "./codexAppServerProcess";
+import { runCodexAuthAppServerTurn } from "./codexAuthAppServerTransport";
 
 function extractTextFromCodexSSE(raw: string): string {
   const lines = raw.split(/\r?\n/);
@@ -238,64 +231,34 @@ export async function runCodexAppServerConnectionTest(params: {
   modelName: string;
   codexPath?: string;
 }): Promise<{ reply: string; capabilityLabel: string }> {
-  const processKey = `codex_app_server_connection_test_${Date.now()}_${Math.random()
-    .toString(16)
-    .slice(2)}`;
-  const processOptions = {
-    codexPath: resolveCodexAppServerBinaryPath(params.codexPath),
-  };
-  const proc = await getOrCreateCodexAppServerProcess(
-    processKey,
-    processOptions,
+  const reply = await runCodexAuthAppServerTurn({
+    model: params.modelName,
+    codexPath: params.codexPath,
+    messages: [
+      {
+        role: "system",
+        content: "You are a concise assistant. Reply with OK.",
+      },
+      { role: "user", content: "Say OK" },
+    ],
+  });
+
+  const request = {
+    conversationKey: 0,
+    mode: "agent" as const,
+    userText: "",
+    authMode: "codex_app_server" as const,
+    model: params.modelName,
+  } as AgentRuntimeRequest;
+  const capabilities =
+    createAgentModelAdapter(request).getCapabilities(request);
+  const capabilityLabel = describeAgentCapabilityClass(
+    getAgentCapabilityClass({
+      toolCalls: capabilities.toolCalls,
+      fileInputs: capabilities.fileInputs,
+    }),
   );
-  try {
-    const reply = await proc.runTurnExclusive(async () => {
-      const threadResp = await proc.sendRequest("thread/start", {
-        model: params.modelName || undefined,
-        ephemeral: true,
-        approvalPolicy: "never",
-      });
-      const threadId = extractCodexAppServerThreadId(threadResp);
-      if (!threadId) {
-        throw new Error("Codex app-server did not return a thread ID");
-      }
-
-      const turnResp = await proc.sendRequest("turn/start", {
-        threadId,
-        input: [{ type: "text", text: "Say OK" }],
-      });
-      const turnId = extractCodexAppServerTurnId(turnResp);
-      if (!turnId) {
-        throw new Error("Codex app-server did not return a turn ID");
-      }
-
-      return waitForCodexAppServerTurnCompletion({
-        proc,
-        turnId,
-        cacheKey: processKey,
-        processOptions,
-      });
-    });
-
-    const request = {
-      conversationKey: 0,
-      mode: "agent" as const,
-      userText: "",
-      authMode: "codex_app_server" as const,
-      model: params.modelName,
-    } as AgentRuntimeRequest;
-    const capabilities =
-      createAgentModelAdapter(request).getCapabilities(request);
-    const capabilityLabel = describeAgentCapabilityClass(
-      getAgentCapabilityClass({
-        toolCalls: capabilities.toolCalls,
-        fileInputs: capabilities.fileInputs,
-      }),
-    );
-    return { reply: reply.trim() || "OK", capabilityLabel };
-  } finally {
-    destroyCachedCodexAppServerProcess(processKey, undefined, processOptions);
-  }
+  return { reply: reply.trim() || "OK", capabilityLabel };
 }
 
 export async function runProviderConnectionTest(params: {
@@ -306,6 +269,22 @@ export async function runProviderConnectionTest(params: {
   apiKey: string;
   modelName: string;
 }): Promise<{ reply: string; capabilityLabel: string }> {
+  if (params.authMode === "codex_auth") {
+    const reply = await runCodexAuthAppServerTurn({
+      model: params.modelName,
+      messages: [
+        {
+          role: "system",
+          content: "You are a concise assistant. Reply with OK.",
+        },
+        { role: "user", content: "Say OK" },
+      ],
+    });
+    return {
+      reply: reply.trim() || "OK",
+      capabilityLabel: getProviderConnectionCapabilityLabel(params),
+    };
+  }
   const { body, expectsSse } = buildConnectionRequestPayload({
     protocol: params.protocol,
     modelName: params.modelName,

--- a/src/utils/providerTransport.ts
+++ b/src/utils/providerTransport.ts
@@ -269,6 +269,7 @@ export function buildProviderTransportHeaders(params: {
   protocol: ProviderProtocol;
   apiKey: string;
   authMode?: ModelProviderAuthMode;
+  codexAccountId?: string;
 }): Record<string, string> {
   if (
     params.protocol === "codex_responses" ||
@@ -285,7 +286,14 @@ export function buildProviderTransportHeaders(params: {
         "Openai-Intent": "conversation-panel",
       };
     }
-    return buildHeaders(params.apiKey);
+    const headers = buildHeaders(params.apiKey);
+    if (params.authMode === "codex_auth") {
+      headers.Originator = "codex";
+      if (params.codexAccountId?.trim()) {
+        headers["ChatGPT-Account-ID"] = params.codexAccountId.trim();
+      }
+    }
+    return headers;
   }
   if (params.protocol === "anthropic_messages") {
     return {

--- a/test/codexAppServerProcess.test.ts
+++ b/test/codexAppServerProcess.test.ts
@@ -1751,6 +1751,55 @@ describe("codexAppServerProcess", function () {
     assert.deepEqual(calls[0]?.arguments, ["app-server"]);
   });
 
+  it("passes isolated config overrides to the app-server process", async function () {
+    const calls: SubprocessCallOptions[] = [];
+
+    await withRuntimeStubs(
+      {
+        env: { CODEX_PATH: "C:\\Tools\\Codex\\codex.exe" },
+        platform: "windows",
+        stubProcessLifecycle: true,
+        subprocessCall: createSpawnStub(calls),
+      },
+      async () => {
+        const proc = await CodexAppServerProcess.spawn({
+          configOverrides: ["mcp_servers={}"],
+        });
+        proc.destroy();
+      },
+    );
+
+    assert.deepEqual(calls[0]?.arguments, [
+      "app-server",
+      "-c",
+      "mcp_servers={}",
+    ]);
+  });
+
+  it("appends a process-specific Codex home", async function () {
+    const calls: SubprocessCallOptions[] = [];
+
+    await withRuntimeStubs(
+      {
+        env: { CODEX_PATH: "C:\\Tools\\Codex\\codex.exe" },
+        platform: "windows",
+        stubProcessLifecycle: true,
+        subprocessCall: createSpawnStub(calls),
+      },
+      async () => {
+        const proc = await CodexAppServerProcess.spawn({
+          environment: { CODEX_HOME: "C:\\CodexIsolated" },
+        });
+        proc.destroy();
+      },
+    );
+
+    assert.deepInclude(calls[0]?.environment, {
+      CODEX_HOME: "C:\\CodexIsolated",
+    });
+    assert.isTrue(calls[0]?.environmentAppend);
+  });
+
   it("uses an explicit codex path before environment or PATH lookup", async function () {
     const binary = await resolveCodexBinary("D:\\Portable\\codex.cmd");
     assert.equal(binary, "D:\\Portable\\codex.cmd");

--- a/test/codexResponsesAgentAdapter.test.ts
+++ b/test/codexResponsesAgentAdapter.test.ts
@@ -1,5 +1,7 @@
 import { assert } from "chai";
 import {
+  buildCodexAgentAppServerMessages,
+  buildCodexFallbackMcpToolActivityEvent,
   CodexResponsesAgentAdapter,
   limitNormalizedResponsesStep,
   normalizeStepFromPayload,
@@ -37,6 +39,121 @@ describe("CodexResponsesAgentAdapter", function () {
 
   it("supports tool calling for codex auth requests", function () {
     assert.isTrue(adapter.supportsTools(makeRequest()));
+  });
+
+  it("preserves Agent tool evidence for the app-server fallback", function () {
+    assert.deepEqual(
+      buildCodexAgentAppServerMessages([
+        { role: "system", content: "Use Zotero context." },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            { id: "call_1", name: "read_paper", arguments: { page: 2 } },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_1",
+          name: "read_paper",
+          content: "Evidence from page 2",
+        },
+      ]),
+      [
+        { role: "system", content: "Use Zotero context." },
+        {
+          role: "assistant",
+          content: '[Tool call: read_paper, call_id=call_1]\n{"page":2}',
+        },
+        {
+          role: "user",
+          content:
+            "[Tool result: read_paper, call_id=call_1]\nEvidence from page 2",
+        },
+      ],
+    );
+  });
+
+  it("maps fallback MCP activity into the persisted Codex tool trace", function () {
+    assert.deepEqual(
+      buildCodexFallbackMcpToolActivityEvent({
+        requestId: "jsonrpc:2",
+        phase: "completed",
+        toolName: "paper_read",
+        toolLabel: "Read Paper",
+        serverName: "llm_for_zotero",
+        arguments: { mode: "overview", itemId: 20031 },
+        ok: true,
+        conversationKey: 42,
+        timestamp: 1234,
+      }),
+      {
+        type: "codex_tool_activity",
+        itemId: "mcp:jsonrpc:2",
+        phase: "completed",
+        toolName: "paper_read",
+        toolLabel: "Read Paper",
+        serverName: "llm_for_zotero",
+        args: { mode: "overview", itemId: 20031 },
+        ok: true,
+        text: undefined,
+        artifacts: undefined,
+      },
+    );
+  });
+
+  it("falls back to Codex app-server when Zotero fetch fails in Agent mode", async function () {
+    let fallbackRequest:
+      | Parameters<
+          ConstructorParameters<typeof CodexResponsesAgentAdapter>[0]
+        >[0]
+      | undefined;
+    const deltas: string[] = [];
+    const fallbackAdapter = new CodexResponsesAgentAdapter(async (params) => {
+      fallbackRequest = params;
+      params.onDelta?.("Fallback OK");
+      return "Fallback OK";
+    });
+    (
+      globalThis as typeof globalThis & {
+        ztoolkit: { getGlobal: (name: string) => unknown };
+      }
+    ).ztoolkit = {
+      getGlobal: (name: string) => {
+        if (name !== "fetch") return undefined;
+        return async () => {
+          throw new TypeError(
+            "NetworkError when attempting to fetch resource.",
+          );
+        };
+      },
+    };
+
+    const step = await fallbackAdapter.runStep({
+      request: makeRequest({
+        model: "gpt-5.6-sol",
+        authMode: "api_key",
+        apiKey: "test-token",
+      }),
+      messages: [
+        { role: "system", content: "Answer from the paper context." },
+        { role: "user", content: "What is the model expression?" },
+      ],
+      tools: [],
+      onTextDelta: (delta) => deltas.push(delta),
+    });
+
+    assert.deepEqual(step, {
+      kind: "final",
+      text: "Fallback OK",
+      assistantMessage: { role: "assistant", content: "Fallback OK" },
+    });
+    assert.equal(fallbackRequest?.model, "gpt-5.6-sol");
+    assert.deepEqual(fallbackRequest?.messages, [
+      { role: "system", content: "Answer from the paper context." },
+      { role: "user", content: "What is the model expression?" },
+    ]);
+    assert.deepEqual(deltas, ["Fallback OK"]);
   });
 
   it("extracts tool calls from responses payload output items", function () {

--- a/test/llmClient.prepareChatRequest.test.ts
+++ b/test/llmClient.prepareChatRequest.test.ts
@@ -861,12 +861,20 @@ describe("llmClient prepareChatRequest", function () {
     ).set(versionKey, 2);
 
     const authJson = JSON.stringify({
-      tokens: { access_token: "old-access", refresh_token: "refresh-1" },
+      tokens: {
+        access_token: "old-access",
+        refresh_token: "refresh-1",
+        account_id: "account-123",
+      },
       last_refresh: "2026-01-01T00:00:00.000Z",
     });
     const writes: string[] = [];
+    const apiHeaders: Array<Record<string, string>> = [];
     let apiCallCount = 0;
-    const fetchMock = async (url: string) => {
+    const fetchMock = async (
+      url: string,
+      options?: { headers?: Record<string, string> },
+    ) => {
       if (url === "https://auth.openai.com/oauth/token") {
         return {
           ok: true,
@@ -880,6 +888,7 @@ describe("llmClient prepareChatRequest", function () {
         };
       }
       apiCallCount += 1;
+      apiHeaders.push(options?.headers || {});
       if (apiCallCount === 1) {
         return {
           ok: false,
@@ -927,6 +936,14 @@ describe("llmClient prepareChatRequest", function () {
     });
     assert.equal(output, "OK after refresh");
     assert.equal(apiCallCount, 2);
+    assert.deepEqual(
+      apiHeaders.map((headers) => headers["ChatGPT-Account-ID"]),
+      ["account-123", "account-123"],
+    );
+    assert.deepEqual(
+      apiHeaders.map((headers) => headers.Originator),
+      ["codex", "codex"],
+    );
     assert.isAtLeast(writes.length, 1);
     assert.include(writes[writes.length - 1], "new-access");
   });

--- a/test/providerConnectionTest.test.ts
+++ b/test/providerConnectionTest.test.ts
@@ -1,0 +1,120 @@
+import { assert } from "chai";
+import {
+  runCodexAppServerConnectionTest,
+  runProviderConnectionTest,
+} from "../src/utils/providerConnectionTest";
+
+describe("provider connection tests", function () {
+  it("tests native Codex with the configured native app-server turn", async function () {
+    let received:
+      | {
+          model: string;
+          codexPath?: string;
+        }
+      | undefined;
+
+    const result = await runCodexAppServerConnectionTest({
+      modelName: "gpt-5.6-sol",
+      codexPath: "C:\\tools\\codex.cmd",
+      runTurn: async (params) => {
+        received = params;
+        return " native OK ";
+      },
+    });
+
+    assert.equal(result.reply, "native OK");
+    assert.deepInclude(received, {
+      model: "gpt-5.6-sol",
+      codexPath: "C:\\tools\\codex.cmd",
+    });
+  });
+
+  it("tests the configured legacy Codex endpoint before using fallback", async function () {
+    let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
+    let fallbackCalls = 0;
+    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestedUrl = String(input);
+      requestedInit = init;
+      return new Response('data: {"delta":"OK"}\n\ndata: [DONE]\n\n', {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    const result = await runProviderConnectionTest({
+      fetchFn,
+      protocol: "codex_responses",
+      authMode: "codex_auth",
+      apiBase: "https://example.test/custom/responses",
+      apiKey: "access-token",
+      codexAccountId: "account-123",
+      modelName: "gpt-5.5",
+      runCodexFallback: async () => {
+        fallbackCalls += 1;
+        return "fallback";
+      },
+    });
+
+    assert.equal(result.reply, "OK");
+    assert.equal(requestedUrl, "https://example.test/custom/responses");
+    const headers = requestedInit?.headers as Record<string, string>;
+    assert.equal(headers.Authorization, "Bearer access-token");
+    assert.equal(headers.Originator, "codex");
+    assert.equal(headers["ChatGPT-Account-ID"], "account-123");
+    assert.equal(fallbackCalls, 0);
+  });
+
+  it("falls back only after a legacy Codex fetch transport failure", async function () {
+    let directCalls = 0;
+    let fallbackCalls = 0;
+    const fetchFn = (async () => {
+      directCalls += 1;
+      throw new TypeError("NetworkError when attempting to fetch resource.");
+    }) as typeof fetch;
+
+    const result = await runProviderConnectionTest({
+      fetchFn,
+      protocol: "codex_responses",
+      authMode: "codex_auth",
+      apiBase: "https://chatgpt.com/backend-api/codex/responses",
+      apiKey: "access-token",
+      modelName: "gpt-5.6-terra",
+      runCodexFallback: async (params) => {
+        fallbackCalls += 1;
+        assert.equal(params.model, "gpt-5.6-terra");
+        return "fallback OK";
+      },
+    });
+
+    assert.equal(result.reply, "fallback OK");
+    assert.equal(directCalls, 1);
+    assert.equal(fallbackCalls, 1);
+  });
+
+  it("does not hide a legacy Codex HTTP configuration error with fallback", async function () {
+    let fallbackCalls = 0;
+    const fetchFn = (async () =>
+      new Response("wrong endpoint", { status: 404 })) as typeof fetch;
+
+    let thrown: unknown;
+    try {
+      await runProviderConnectionTest({
+        fetchFn,
+        protocol: "codex_responses",
+        authMode: "codex_auth",
+        apiBase: "https://example.test/wrong/responses",
+        apiKey: "access-token",
+        modelName: "gpt-5.5",
+        runCodexFallback: async () => {
+          fallbackCalls += 1;
+          return "fallback";
+        },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    assert.match(String(thrown), /HTTP 404: wrong endpoint/);
+    assert.equal(fallbackCalls, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the legacy Codex-auth transport without merging it with the native Codex Agent runtime, and populate both Codex settings surfaces from the live app-server model catalog.

Fixes #366.
Related: #309, #305, #304.

## What changed

- Keep the legacy direct Codex request as the first attempt.
- Retry through a **separate isolated** `codex app-server` only for Zotero/Gecko fetch transport failures (`TypeError: NetworkError when attempting to fetch resource`) that occur before any HTTP response.
- Do not reuse or mutate the native Codex Agent process.
- Run the legacy fallback with an isolated `CODEX_HOME` that shares only `auth.json` via a hard link; global MCP servers, skills, plugins, and shell snapshot are excluded.
- Keep ordinary legacy chat tool-free. When the user explicitly enables Agent(beta), attach only that turn's scoped Zotero MCP server and persist its tool activity back into the Agent trace.
- Preserve existing Agent tool-call/result evidence when converting a failed Responses turn into app-server input.
- Include `ChatGPT-Account-ID` and `Originator: codex` on direct Codex-auth requests, including refreshed-token retries.
- Populate model suggestions in both:
  - AI Providers -> Codex Auth (legacy)
  - Agent -> Codex App Server
- Validate the selected Agent model against live `model/list` before testing.
- Keep model-catalog/MCP probes isolated from active turn processes.

## Why the isolation matters

The owner feedback in #366 correctly notes that legacy Codex Auth and native Codex App Server are intentionally different modes. This revision preserves that boundary:

- separate process key and separate `CODEX_HOME`;
- no native thread/session reuse;
- no MCP tools in ordinary legacy chat;
- one scoped Zotero MCP server only after Agent(beta) was explicitly selected;
- fallback only for a pre-response Gecko transport exception, not for HTTP/model/auth errors.

## Root cause

The same authenticated Codex request fails inside Zotero's privileged Gecko runtime before a response is available. Zotero's alternate privileged HTTP path also fails in this environment, while the installed native Codex app-server succeeds. Header and token-refresh fixes alone therefore cannot repair this Windows/Zotero transport failure.

Separately, the installed app-server `model/list` reports the suffixed 5.6 slugs (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) rather than a generic `gpt-5.6` alias.

## Validation

Environment: Windows 11, Zotero 9.0.6, Codex CLI 0.145.0-alpha.4.

Automated:

- 190 affected runtime/Codex/MCP tests pass
- `npm run typecheck`
- `npm run check:cycles`
- production XPI build succeeds

Real Zotero UI turns:

| Path | Model | Result |
| --- | --- | --- |
| Legacy provider, Agent off | `gpt-5.5` | pass |
| Legacy provider, Agent off | `gpt-5.6-sol` | pass |
| Legacy provider, Agent off | `gpt-5.6-terra` | pass |
| Legacy provider, Agent off | `gpt-5.6-luna` | pass |
| Legacy provider + Agent(beta) | `gpt-5.5` | pass |
| Legacy provider + Agent(beta) | `gpt-5.6-sol` | pass |
| Legacy provider + Agent(beta) | `gpt-5.6-terra` | pass |
| Legacy provider + Agent(beta) | `gpt-5.6-luna` | pass |
| Native Codex Agent | `gpt-5.6-sol` | pass (`NATIVE_CODEX_SOL_OK`) |
| Native Codex Agent | `gpt-5.6-terra` | pass (`NATIVE_CODEX_TERRA_OK`) |
| Native Codex Agent | `gpt-5.6-luna` | pass (`NATIVE_CODEX_LUNA_OK`) |

The strict Agent(beta) paper test produced persisted `codex_tool_activity` events for `paper_read`: `started`, then `completed` with `ok: true`, using the current paper's scoped item/context IDs. No tested path reproduced the original `NetworkError`.

Local packaged build 3.8.48 was installed and verified after cold startup with the add-on active, initialized, Agent API ready, and the chat input in Ready state.