### PR TITLE
feat: recognize OrcaRouter as a named third-party provider label

### DIFF
--- a/src/utils/modelProviders.ts
+++ b/src/utils/modelProviders.ts
@@ -222,6 +222,7 @@ export function deriveProviderLabel(
     return "Together.ai";
   }
   if (lowerHost.includes("openrouter.ai")) return "OpenRouter";
+  if (lowerHost.includes("orcarouter.ai")) return "OrcaRouter";
   if (lowerHost === "x.ai" || lowerHost.endsWith(".x.ai")) return "Grok";
   if (lowerHost.includes("groq.com")) return "Groq";
   if (lowerHost.includes("dashscope") || lowerHost.includes("aliyuncs.com")) {

--- a/test/modelProviders.test.ts
+++ b/test/modelProviders.test.ts
@@ -53,9 +53,14 @@ describe("modelProviders", function () {
     );
     assert.equal(deriveProviderLabel("https://api.moonshot.ai/v1"), "Kimi");
     assert.equal(deriveProviderLabel("https://api.x.ai/v1/responses"), "Grok");
+    assert.equal(deriveProviderLabel("https://api.xiaomimimo.com/v1"), "Xiaomi MiMo");
     assert.equal(
-      deriveProviderLabel("https://api.xiaomimimo.com/v1"),
-      "Xiaomi MiMo",
+      deriveProviderLabel("https://openrouter.ai/api/v1"),
+      "OpenRouter",
+    );
+    assert.equal(
+      deriveProviderLabel("https://api.orcarouter.ai/v1"),
+      "OrcaRouter",
     );
     assert.equal(
       deriveProviderLabel("https://api.minimax.io/anthropic"),


### PR DESCRIPTION
# Recognize OrcaRouter as a named third-party provider label

## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a recognized provider label in the plugin's provider-name detection. OrcaRouter is an OpenAI/Anthropic-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `src/utils/modelProviders.ts`: in `deriveProviderLabel`, mirror the existing `openrouter.ai` host-label entry with `if (lowerHost.includes("orcarouter.ai")) return "OrcaRouter";`. Users who configure `https://api.orcarouter.ai/v1` as their API base now see **"OrcaRouter"** as the provider label instead of the raw hostname.
- `test/modelProviders.test.ts`: asserts `deriveProviderLabel("https://api.orcarouter.ai/v1") === "OrcaRouter"` in the known-host label test, alongside the OpenRouter assertion.

## Why a label rather than a preset

This repo has a deliberate provider-tier design: presets in `src/utils/providerPresets.ts` are reserved for **first-party** providers (OpenAI, Gemini, Anthropic, DeepSeek, Grok, Qwen, Kimi, MiMo, etc.), and `src/providers/tiers/native.ts` only classifies the four native presets as Tier-1. **Routers/relays like OpenRouter are intentionally not presets** — they get a host-label in `deriveProviderLabel` and are classified automatically as Tier-3 "third-party compatible" via protocol matching (`src/providers/tiers/thirdParty.ts`, which names OpenRouter explicitly). OrcaRouter is exactly that category, so the faithful, minimal integration is the host-label entry — no preset, no capability change. The `third_party` tier (PDF disabled, images allowed) already applies.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. In plugin preferences, add a provider with base URL `https://api.orcarouter.ai/v1`, the API key, and an OpenAI-compatible protocol (`openai_chat_compat` or `responses_api`).
3. The provider now displays as **OrcaRouter**.

## Verification

- `test/modelProviders.test.ts` → 25 passing (includes the new OrcaRouter assertion)
- `test/providerPresets.test.ts` → 8 passing
- `tsc --noEmit` → clean
