### PR TITLE
fix: keep amber quote cards from rendering empty

### DIFF
--- a/src/modules/contextPanel/assistantCitationLinks.ts
+++ b/src/modules/contextPanel/assistantCitationLinks.ts
@@ -3918,13 +3918,24 @@ function renderQuoteCardBodyMarkdown(
   renderQuoteCardMarkdownInto(body, quoteText, ownerDoc);
 }
 
+// Markdown that sanitizes down to nothing still leaves nodes behind: the
+// renderer swaps a disallowed element for an empty text node rather than
+// dropping it. Node presence therefore proves nothing about what the reader
+// will see, so ask for text or for an element that paints on its own. A lone
+// <br> is deliberately absent — it occupies no visible space, and the caller's
+// raw-text fallback shows more than an empty card would.
+const QUOTE_CARD_SELF_RENDERING_SELECTOR = "img, svg, hr, input";
+
+function hasRenderableQuoteCardContent(source: ParentNode): boolean {
+  if ((source.textContent || "").trim()) return true;
+  return Boolean(source.querySelector?.(QUOTE_CARD_SELF_RENDERING_SELECTOR));
+}
+
 function appendQuoteCardBodyContent(
   body: HTMLElement,
   quoteContent: ParentNode | null | undefined,
 ): boolean {
   if (!quoteContent?.firstChild) return false;
-  const existingChildCount = body.childNodes.length;
-  body.classList.add("llm-rendered-markdown");
   const firstElement =
     "firstElementChild" in quoteContent ? quoteContent.firstElementChild : null;
   const hasSingleParagraph =
@@ -3932,21 +3943,17 @@ function appendQuoteCardBodyContent(
     firstElement?.tagName.toLowerCase() === "p";
   const moveSource =
     hasSingleParagraph && firstElement ? firstElement : quoteContent;
+  // Decide before mutating. Rolling back after the move would strand the
+  // caller's nodes and leave `quoteContent` unusable for the fallback render.
+  if (!hasRenderableQuoteCardContent(moveSource)) return false;
+  body.classList.add("llm-rendered-markdown");
   while (moveSource.firstChild) {
     body.appendChild(moveSource.firstChild);
   }
-  const movedRenderableContent =
-    Boolean(body.textContent?.trim()) ||
-    Boolean(body.querySelector("img, svg"));
-  if (!movedRenderableContent) {
-    while (body.childNodes.length > existingChildCount) {
-      body.removeChild(body.lastChild as ChildNode);
-    }
-    body.classList.remove("llm-rendered-markdown");
-    return false;
-  }
   return true;
 }
+
+export const appendQuoteCardBodyContentForTests = appendQuoteCardBodyContent;
 
 function createQuoteCardElement(params: {
   ownerDoc: Document;

--- a/src/modules/contextPanel/assistantCitationLinks.ts
+++ b/src/modules/contextPanel/assistantCitationLinks.ts
@@ -3923,6 +3923,7 @@ function appendQuoteCardBodyContent(
   quoteContent: ParentNode | null | undefined,
 ): boolean {
   if (!quoteContent?.firstChild) return false;
+  const existingChildCount = body.childNodes.length;
   body.classList.add("llm-rendered-markdown");
   const firstElement =
     "firstElementChild" in quoteContent ? quoteContent.firstElementChild : null;
@@ -3933,6 +3934,16 @@ function appendQuoteCardBodyContent(
     hasSingleParagraph && firstElement ? firstElement : quoteContent;
   while (moveSource.firstChild) {
     body.appendChild(moveSource.firstChild);
+  }
+  const movedRenderableContent =
+    Boolean(body.textContent?.trim()) ||
+    Boolean(body.querySelector("img, svg"));
+  if (!movedRenderableContent) {
+    while (body.childNodes.length > existingChildCount) {
+      body.removeChild(body.lastChild as ChildNode);
+    }
+    body.classList.remove("llm-rendered-markdown");
+    return false;
   }
   return true;
 }

--- a/test/quoteCardUi.test.ts
+++ b/test/quoteCardUi.test.ts
@@ -2,11 +2,143 @@ import { assert } from "chai";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { appendQuoteCardBodyContentForTests } from "../src/modules/contextPanel/assistantCitationLinks";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
 function source(path: string): string {
   return readFileSync(resolve(here, "..", path), "utf8");
+}
+
+/**
+ * Minimal DOM stand-in for the quote-card body plumbing. Zotero runs on Gecko
+ * and the suite has no DOM library, so the pieces the renderer actually uses
+ * are modelled here with real DOM semantics: `appendChild` moves a node out of
+ * its previous parent, `textContent` concatenates descendant text, and
+ * `querySelector` matches descendants only. Anything unmodelled throws rather
+ * than quietly answering, so a fake that drifts from Gecko fails loudly.
+ */
+class FakeClassList {
+  private readonly tokens = new Set<string>();
+
+  add(...names: string[]): void {
+    for (const name of names) this.tokens.add(name);
+  }
+
+  remove(...names: string[]): void {
+    for (const name of names) this.tokens.delete(name);
+  }
+
+  contains(name: string): boolean {
+    return this.tokens.has(name);
+  }
+}
+
+class FakeNode {
+  public parentNode: FakeNode | null = null;
+  public readonly childNodes: FakeNode[] = [];
+
+  get firstChild(): FakeNode | null {
+    return this.childNodes[0] || null;
+  }
+
+  get lastChild(): FakeNode | null {
+    return this.childNodes[this.childNodes.length - 1] || null;
+  }
+
+  get firstElementChild(): FakeElement | null {
+    return (
+      this.childNodes.find(
+        (child): child is FakeElement => child instanceof FakeElement,
+      ) || null
+    );
+  }
+
+  get textContent(): string {
+    return this.childNodes.map((child) => child.textContent).join("");
+  }
+
+  appendChild(child: FakeNode): FakeNode {
+    child.parentNode?.removeChild(child);
+    child.parentNode = this;
+    this.childNodes.push(child);
+    return child;
+  }
+
+  removeChild(child: FakeNode): FakeNode {
+    const index = this.childNodes.indexOf(child);
+    if (index < 0) throw new Error("removeChild: node is not a child");
+    this.childNodes.splice(index, 1);
+    child.parentNode = null;
+    return child;
+  }
+
+  /** Supports only the comma-separated tag-name selectors the renderer uses. */
+  querySelector(selector: string): FakeElement | null {
+    const tagNames = selector.split(",").map((part) => part.trim());
+    if (!tagNames.length || tagNames.some((name) => !/^[a-z]+$/.test(name))) {
+      throw new Error(`fake querySelector cannot parse selector: ${selector}`);
+    }
+    for (const child of this.childNodes) {
+      if (
+        child instanceof FakeElement &&
+        tagNames.includes(child.tagName.toLowerCase())
+      ) {
+        return child;
+      }
+      const nested = child.querySelector(selector);
+      if (nested) return nested;
+    }
+    return null;
+  }
+}
+
+class FakeText extends FakeNode {
+  constructor(private readonly data: string) {
+    super();
+  }
+
+  get textContent(): string {
+    return this.data;
+  }
+
+  override appendChild(): FakeNode {
+    throw new Error("text nodes cannot have children");
+  }
+}
+
+class FakeElement extends FakeNode {
+  public readonly classList = new FakeClassList();
+  public readonly tagName: string;
+
+  constructor(tagName: string) {
+    super();
+    this.tagName = tagName.toUpperCase();
+  }
+}
+
+class FakeFragment extends FakeNode {}
+
+function element(tagName: string, ...children: FakeNode[]): FakeElement {
+  const node = new FakeElement(tagName);
+  for (const child of children) node.appendChild(child);
+  return node;
+}
+
+function fragment(...children: FakeNode[]): FakeFragment {
+  const node = new FakeFragment();
+  for (const child of children) node.appendChild(child);
+  return node;
+}
+
+function appendBodyContent(
+  body: FakeElement,
+  quoteContent: FakeNode | null,
+): boolean {
+  return appendQuoteCardBodyContentForTests(
+    body as unknown as HTMLElement,
+    quoteContent as unknown as ParentNode | null,
+  );
 }
 
 describe("quote card UI contract", function () {
@@ -159,28 +291,107 @@ describe("quote card UI contract", function () {
     );
   });
 
-  it("falls back to the quote text when the prerendered body has no content", function () {
-    const renderSource = source(
-      "src/modules/contextPanel/assistantCitationLinks.ts",
-    );
-    const appendStart = renderSource.indexOf(
-      "function appendQuoteCardBodyContent(",
-    );
-    const appendEnd = renderSource.indexOf(
-      "function createQuoteCardElement(",
-      appendStart,
-    );
-    const appendSource = renderSource.slice(appendStart, appendEnd);
+  it("adopts a prerendered body that carries visible text", function () {
+    const body = element("div");
+    const paragraph = element("p", new FakeText("Attention is all you need."));
 
-    assert.isAtLeast(appendStart, 0);
-    assert.isAbove(appendEnd, appendStart);
-    assert.include(appendSource, "const movedRenderableContent =");
-    assert.include(appendSource, "body.textContent?.trim()");
-    assert.include(appendSource, "if (!movedRenderableContent) {");
-    assert.include(
-      appendSource,
-      'body.classList.remove("llm-rendered-markdown")',
+    assert.isTrue(appendBodyContent(body, fragment(paragraph)));
+    assert.equal(body.textContent, "Attention is all you need.");
+    assert.isTrue(body.classList.contains("llm-rendered-markdown"));
+    assert.equal(paragraph.childNodes.length, 0);
+  });
+
+  it("rejects a prerendered body whose content sanitized away to nothing", function () {
+    const body = element("div");
+    const quoteContent = fragment(element("p", new FakeText("")));
+
+    assert.isFalse(appendBodyContent(body, quoteContent));
+    assert.equal(body.childNodes.length, 0);
+    assert.isFalse(body.classList.contains("llm-rendered-markdown"));
+  });
+
+  it("rejects a blockquote that rendered to whitespace around an emptied paragraph", function () {
+    // The shape the Markdown renderer actually hands over for the reported
+    // bug: newline text nodes around a paragraph whose only child was swapped
+    // for an empty text node by the sanitizer. Every node here is real, so
+    // node presence alone reports success and the card paints empty.
+    const body = element("div");
+    const quoteContent = fragment(
+      new FakeText("\n"),
+      element("p", new FakeText("")),
+      new FakeText("\n"),
     );
+
+    assert.isFalse(appendBodyContent(body, quoteContent));
+    assert.equal(body.childNodes.length, 0);
+    assert.equal(quoteContent.childNodes.length, 3);
+  });
+
+  it("adopts a blockquote that rendered to whitespace around real text", function () {
+    const body = element("div");
+    const quoteContent = fragment(
+      new FakeText("\n"),
+      element(
+        "p",
+        new FakeText("Scaling laws hold across orders of magnitude."),
+      ),
+      new FakeText("\n"),
+    );
+
+    assert.isTrue(appendBodyContent(body, quoteContent));
+    assert.equal(
+      body.textContent,
+      "\nScaling laws hold across orders of magnitude.\n",
+    );
+    assert.equal(quoteContent.childNodes.length, 0);
+  });
+
+  it("leaves the prerendered content intact when it rejects it", function () {
+    const emptied = element("p", new FakeText(""));
+    const quoteContent = fragment(emptied);
+
+    assert.isFalse(appendBodyContent(element("div"), quoteContent));
+    assert.equal(quoteContent.childNodes.length, 1);
+    assert.strictEqual(quoteContent.firstChild, emptied);
+    assert.equal(emptied.childNodes.length, 1);
+  });
+
+  it("keeps content that renders visibly without contributing text", function () {
+    // A rule and a task-list checkbox both paint on their own; the sanitizer
+    // only ever lets an <input> through as a checkbox.
+    for (const tagName of ["hr", "input"]) {
+      const body = element("div");
+
+      assert.isTrue(
+        appendBodyContent(body, fragment(element(tagName))),
+        `expected <${tagName}> to count as visible content`,
+      );
+      assert.isTrue(body.classList.contains("llm-rendered-markdown"));
+      assert.equal(body.childNodes.length, 1);
+    }
+  });
+
+  it("does not count a bare line break as visible content", function () {
+    const body = element("div");
+
+    assert.isFalse(appendBodyContent(body, fragment(element("br"))));
+    assert.equal(body.childNodes.length, 0);
+  });
+
+  it("judges the incoming content, not text the body already holds", function () {
+    const body = element("div", new FakeText("Loading…"));
+
+    assert.isFalse(appendBodyContent(body, fragment(element("p"))));
+    assert.equal(body.textContent, "Loading…");
+    assert.equal(body.childNodes.length, 1);
+  });
+
+  it("keeps a markdown class the body already carried", function () {
+    const body = element("div");
+    body.classList.add("llm-rendered-markdown");
+
+    assert.isFalse(appendBodyContent(body, fragment(element("p"))));
+    assert.isTrue(body.classList.contains("llm-rendered-markdown"));
   });
 
   it("renders collapsed quote-card previews as lightweight plain text", function () {

--- a/test/quoteCardUi.test.ts
+++ b/test/quoteCardUi.test.ts
@@ -159,6 +159,30 @@ describe("quote card UI contract", function () {
     );
   });
 
+  it("falls back to the quote text when the prerendered body has no content", function () {
+    const renderSource = source(
+      "src/modules/contextPanel/assistantCitationLinks.ts",
+    );
+    const appendStart = renderSource.indexOf(
+      "function appendQuoteCardBodyContent(",
+    );
+    const appendEnd = renderSource.indexOf(
+      "function createQuoteCardElement(",
+      appendStart,
+    );
+    const appendSource = renderSource.slice(appendStart, appendEnd);
+
+    assert.isAtLeast(appendStart, 0);
+    assert.isAbove(appendEnd, appendStart);
+    assert.include(appendSource, "const movedRenderableContent =");
+    assert.include(appendSource, "body.textContent?.trim()");
+    assert.include(appendSource, "if (!movedRenderableContent) {");
+    assert.include(
+      appendSource,
+      'body.classList.remove("llm-rendered-markdown")',
+    );
+  });
+
   it("renders collapsed quote-card previews as lightweight plain text", function () {
     const renderSource = source(
       "src/modules/contextPanel/assistantCitationLinks.ts",


### PR DESCRIPTION
### Problem

Amber quote cards (`status: "not-source"` / `"unverified"`) sometimes render as an empty card — the rail and padding are there, but no text. Verified cards in the same message render fine.

### Path

`renderImmediateQuoteBodiesBatch()` renders all immediate quote bodies in one Markdown pass and hands each occurrence a `DocumentFragment`. Amber cards are non-interactive, so `createQuoteCardElement()` calls `ensureBodyRendered()` eagerly at construction time:

```ts
const ensureBodyRendered = () => {
  if (bodyRendered) return;
  bodyRendered = true;
  if (!appendQuoteCardBodyContent(body, params.quoteContent)) {
    renderQuoteCardBodyMarkdown(body, params.quoteText, params.ownerDoc);
  }
};
```

### Cause

`appendQuoteCardBodyContent()` decides success from `quoteContent.firstChild` alone and then returns `true` unconditionally. If the fragment carries no renderable content, it moves nothing meaningful into `body` and still reports success, so the `params.quoteText` fallback is skipped. `bodyRendered` is already latched at that point, so the card stays empty until the message is re-rendered.

Verified cards don't hit this: their visible text comes from `params.quoteText` through `preview`, and the body is rendered lazily on expand, by which point the fragment is complete.

### Fix

Return `true` only when renderable content actually landed in `body`. Otherwise roll back the moved nodes, drop the `llm-rendered-markdown` class, and return `false` so the existing `quoteText` fallback runs as intended.

Regression assertion added in `test/quoteCardUi.test.ts`.
