### PR TITLE
fix(note): preserve heading levels during note edits

### DIFF
--- a/src/agent/services/zoteroGateway.ts
+++ b/src/agent/services/zoteroGateway.ts
@@ -7,6 +7,7 @@ import {
 import {
   createNoteFromAssistantText,
   createStandaloneNoteFromAssistantText,
+  noteHtmlToMarkdownText,
   normalizeNoteSourceText,
   readNoteSnapshot,
   renderRawNoteHtml,
@@ -1635,8 +1636,8 @@ export class ZoteroGateway {
     }
     if (
       typeof params.expectedOriginalHtml === "string" &&
-      normalizeText(snapshot.text) !==
-        normalizeText(stripNoteHtml(params.expectedOriginalHtml))
+      normalizeText(noteHtmlToMarkdownText(snapshot.html)) !==
+        normalizeText(noteHtmlToMarkdownText(params.expectedOriginalHtml))
     ) {
       throw new Error(
         "The active note changed before this edit was applied. Refresh and try again.",

--- a/src/agent/tools/write/editCurrentNote.ts
+++ b/src/agent/tools/write/editCurrentNote.ts
@@ -63,6 +63,10 @@ function htmlHasInlineStyles(html: string): boolean {
 type EditCurrentNoteInput = {
   mode: "edit" | "create" | "append";
   content: string;
+  /** Permit an explicit request to add, remove, or change heading levels.
+   *  Without this opt-in, accidental heading demotion in a full rewrite is
+   *  rejected before the review card is created. */
+  allowHeadingChanges?: boolean;
   expectedOriginalHtml?: string;
   /** Pre-patched HTML computed by applying patches directly to the original
    *  note HTML.  When set, `execute()` uses this instead of round-tripping
@@ -139,6 +143,43 @@ function applyPatches(base: string, patches: NotePatch[]): string {
     }
   }
   return result;
+}
+
+type MarkdownHeading = { level: number; title: string };
+
+function listMarkdownHeadings(text: string): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/^\s{0,3}(#{1,6})[ \t]+(.+?)\s*$/);
+    if (!match) continue;
+    headings.push({
+      level: match[1].length,
+      // CommonMark closing markers require whitespace before the trailing
+      // hashes. Keep a legitimate title such as "C#" intact.
+      title: match[2].replace(/[ \t]+#+[ \t]*$/, "").trim(),
+    });
+  }
+  return headings;
+}
+
+function findChangedOrDemotedHeadings(
+  before: string,
+  after: string,
+): MarkdownHeading[] {
+  const afterHeadings = listMarkdownHeadings(after);
+  const afterLines = new Set(
+    after
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+  return listMarkdownHeadings(before).filter((heading) => {
+    const preserved = afterHeadings.some(
+      (candidate) =>
+        candidate.level === heading.level && candidate.title === heading.title,
+    );
+    return !preserved && afterLines.has(heading.title);
+  });
 }
 
 /**
@@ -436,7 +477,12 @@ export function createEditCurrentNoteTool(
           content: {
             type: "string",
             description:
-              "The full note body as plain text or Markdown. Use this OR patches, not both. Required for mode 'create'.",
+              "The full note body as plain text or Markdown. In edit mode this replaces the entire note, so include all unchanged Markdown heading markers. Use this OR patches, not both. Required for mode 'create'.",
+          },
+          allowHeadingChanges: {
+            type: "boolean",
+            description:
+              "For mode 'edit' only: set true only when the user explicitly asked to add, remove, or change heading levels. Otherwise accidental heading demotion is rejected.",
           },
           patches: {
             type: "array",
@@ -490,7 +536,7 @@ export function createEditCurrentNoteTool(
       matches: () => true,
       instruction:
         "When a Zotero note is already open/current and the user asks to edit, rewrite, revise, polish, or update that note, call `edit_current_note` with mode 'edit'. NEVER output note text directly in chat. " +
-        "For edits, PREFER `patches` (find-and-replace pairs) over `content` (full rewrite). " +
+        "For edits, PREFER `patches` (find-and-replace pairs) over `content` (full rewrite). Full rewrite content replaces the entire note, so preserve every unchanged Markdown heading marker exactly. Set `allowHeadingChanges` only when the user explicitly requests heading restructuring. " +
         "When the user asks to append/add content to an existing note, call `edit_current_note` with mode 'append' and `content`; pass `targetNoteId` when the destination note is known. " +
         "When the user asks to create/write/save a new item note, call `edit_current_note` with mode 'create', target 'item', and `content`; create means a brand-new child note, not appending to the response-save note. " +
         "For standalone notes, call `edit_current_note` with mode 'create', target 'standalone', and `content`. " +
@@ -623,6 +669,10 @@ export function createEditCurrentNoteTool(
         collections:
           mode === "create"
             ? normalizePositiveIntArray(args.collections)
+            : undefined,
+        allowHeadingChanges:
+          mode === "edit" && args.allowHeadingChanges === true
+            ? true
             : undefined,
       } as EditCurrentNoteInput);
     },
@@ -768,6 +818,22 @@ export function createEditCurrentNoteTool(
       const diffAfter = input._isHtml
         ? normalizeNoteSourceText(input.content)
         : normalizedContent;
+
+      if (!input.allowHeadingChanges) {
+        const changedHeadings = findChangedOrDemotedHeadings(
+          snapshot.text,
+          diffAfter,
+        );
+        if (changedHeadings.length) {
+          const labels = changedHeadings
+            .slice(0, 5)
+            .map((heading) => `${"#".repeat(heading.level)} ${heading.title}`)
+            .join(", ");
+          throw new Error(
+            `The proposed edit would remove or change existing heading formatting (${labels}). Preserve the original Markdown heading markers, or set allowHeadingChanges only when the user explicitly requested heading restructuring.`,
+          );
+        }
+      }
 
       return {
         toolName: "edit_current_note",

--- a/src/modules/contextPanel/noteSnapshot.ts
+++ b/src/modules/contextPanel/noteSnapshot.ts
@@ -28,6 +28,27 @@ export function stripNoteHtml(html: string): string {
   return text.replace(/\n{3,}/g, "\n\n").trim();
 }
 
+/**
+ * Convert stored Zotero note HTML into the Markdown-like source shown to the
+ * model.  Zotero keeps heading levels in `<h1>` ... `<h6>` elements; flattening
+ * those elements to plain text makes a later full-note rewrite silently demote
+ * every heading.  Preserve the markers while retaining the lightweight plain
+ * text representation used by the rest of the note context pipeline.
+ */
+export function noteHtmlToMarkdownText(html: string): string {
+  if (!html) return "";
+  const withHeadingMarkers = html.replace(
+    /<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi,
+    (_match, level, content) => {
+      const title = stripNoteHtml(String(content || "")).trim();
+      return title
+        ? `\n\n${"#".repeat(Number(level) || 1)} ${title}\n\n`
+        : "\n";
+    },
+  );
+  return stripNoteHtml(withHeadingMarkers);
+}
+
 export function readNoteSnapshot(
   item: Zotero.Item | null | undefined,
 ): NoteSnapshot | null {
@@ -44,7 +65,7 @@ export function readNoteSnapshot(
         : undefined,
     title: resolveNoteTitle(item),
     html,
-    text: stripNoteHtml(html),
+    text: noteHtmlToMarkdownText(html),
     libraryID: Number(item?.libraryID) || 0,
     parentItemId: parentItem?.id,
     parentItemKey:

--- a/src/modules/contextPanel/notes.ts
+++ b/src/modules/contextPanel/notes.ts
@@ -32,6 +32,7 @@ import type {
   SelectedTextSource,
 } from "./types";
 import {
+  noteHtmlToMarkdownText,
   readNoteSnapshot,
   stripNoteHtml,
   type NoteSnapshot,
@@ -82,7 +83,12 @@ import {
   type NotePersistenceSaveOptions,
 } from "./notePersistence";
 
-export { readNoteSnapshot, stripNoteHtml, type NoteSnapshot };
+export {
+  noteHtmlToMarkdownText,
+  readNoteSnapshot,
+  stripNoteHtml,
+  type NoteSnapshot,
+};
 
 function decodeNoteHtmlEntities(text: string): string {
   return text

--- a/test/agentPrimitiveTools.test.ts
+++ b/test/agentPrimitiveTools.test.ts
@@ -2641,6 +2641,58 @@ describe("primitive agent tools", function () {
     assert.equal(validated.value.noteId, 77);
   });
 
+  it("edit_current_note rejects accidental heading demotion", function () {
+    const tool = createEditCurrentNoteTool({
+      getActiveNoteSnapshot: () => ({
+        noteId: 55,
+        title: "Structured Note",
+        html: "<h1>Overview</h1><h2>Details</h2><p>Body</p>",
+        text: "# Overview\n\n## Details\nBody",
+        libraryID: 1,
+        noteKind: "standalone",
+      }),
+    } as never);
+    const validated = tool.validate({
+      mode: "edit",
+      content: "Overview\n\nDetails\nBody revised",
+    });
+    assert.isTrue(validated.ok);
+    if (!validated.ok) return;
+
+    assert.throws(
+      () => tool.createPendingAction?.(validated.value, baseContext),
+      /remove or change existing heading formatting/,
+    );
+  });
+
+  it("edit_current_note permits explicitly requested heading changes", function () {
+    const tool = createEditCurrentNoteTool({
+      getActiveNoteSnapshot: () => ({
+        noteId: 55,
+        title: "Structured Note",
+        html: "<h1>Overview</h1><p>Body</p>",
+        text: "# Overview\nBody",
+        libraryID: 1,
+        noteKind: "standalone",
+      }),
+    } as never);
+    const validated = tool.validate({
+      mode: "edit",
+      content: "## Overview\nBody",
+      allowHeadingChanges: true,
+    });
+    assert.isTrue(validated.ok);
+    if (!validated.ok) return;
+
+    const pending = tool.createPendingAction?.(validated.value, baseContext);
+    const reviewField = pending?.fields[0] as Extract<
+      NonNullable<typeof pending>["fields"][number],
+      { type: "diff_preview" }
+    >;
+    assert.equal(reviewField.before, "# Overview\nBody");
+    assert.equal(reviewField.after, "## Overview\nBody");
+  });
+
   it("edit_current_note does not police incomplete MinerU figure-block embeds before mutation", async function () {
     let replacedContent = "";
     const tool = createEditCurrentNoteTool({

--- a/test/noteSnapshot.test.ts
+++ b/test/noteSnapshot.test.ts
@@ -1,0 +1,24 @@
+import { assert } from "chai";
+import {
+  noteHtmlToMarkdownText,
+  stripNoteHtml,
+} from "../src/modules/contextPanel/noteSnapshot";
+
+describe("note snapshots", function () {
+  it("preserves Zotero heading levels in the model-facing note text", function () {
+    const html =
+      '<div data-schema-version="9"><h1>Main &amp; title</h1><p>Intro</p><h2><strong>Details</strong></h2><p>Body</p><h6>Fine print</h6></div>';
+
+    assert.equal(
+      noteHtmlToMarkdownText(html),
+      "# Main & title\n\nIntro\n\n## Details\n\nBody\n\n###### Fine print",
+    );
+  });
+
+  it("keeps the plain-text stripper unchanged for comparison callers", function () {
+    assert.equal(
+      stripNoteHtml("<h1>Main</h1><h2>Details</h2>"),
+      "Main\nDetails",
+    );
+  });
+});

--- a/test/zoteroGateway.noteEdits.test.ts
+++ b/test/zoteroGateway.noteEdits.test.ts
@@ -55,4 +55,101 @@ describe("ZoteroGateway current note edits", function () {
     assert.equal(result.nextText, "Updated body");
     assert.include(savedHtml, "Updated body");
   });
+
+  it("accepts note apply when matching headings are present", async function () {
+    let noteHtml =
+      "<div><h1>Overview</h1><h2>Details</h2><p>Original body</p></div>";
+    let savedHtml = "";
+    const noteItem = {
+      id: 56,
+      libraryID: 1,
+      parentID: undefined,
+      isNote: () => true,
+      getNote: () => noteHtml,
+      getDisplayTitle: () => "Structured Note",
+      setNote: (html: string) => {
+        savedHtml = html;
+        noteHtml = html;
+      },
+      saveTx: async () => {},
+    };
+
+    (globalThis as typeof globalThis & { Zotero?: unknown }).Zotero = {
+      Items: {
+        get: (itemId: number) => (itemId === 56 ? noteItem : null),
+      },
+    };
+
+    const gateway = new ZoteroGateway();
+    const result = await gateway.replaceCurrentNote({
+      request: {
+        conversationKey: 8,
+        mode: "agent",
+        userText: "Update the note",
+        activeNoteContext: {
+          noteId: 56,
+          title: "Structured Note",
+          noteKind: "standalone",
+          noteText: "# Overview\n\n## Details\n\nOriginal body",
+        },
+      },
+      content: "# Overview\n\n## Details\n\nUpdated body",
+      expectedOriginalHtml:
+        "<h1>Overview</h1><h2>Details</h2><p>Original body</p>",
+    });
+
+    assert.equal(result.noteId, 56);
+    assert.include(result.previousText, "# Overview");
+    assert.include(result.previousText, "## Details");
+    assert.include(savedHtml, "<h1>Overview</h1>");
+    assert.include(savedHtml, "<h2>Details</h2>");
+  });
+
+  it("still rejects an intervening heading-level change", async function () {
+    const noteHtml = "<div><h2>Overview</h2><p>Original body</p></div>";
+    const noteItem = {
+      id: 57,
+      libraryID: 1,
+      parentID: undefined,
+      isNote: () => true,
+      getNote: () => noteHtml,
+      getDisplayTitle: () => "Changed Note",
+      setNote: () => {},
+      saveTx: async () => {},
+    };
+
+    (globalThis as typeof globalThis & { Zotero?: unknown }).Zotero = {
+      Items: {
+        get: (itemId: number) => (itemId === 57 ? noteItem : null),
+      },
+    };
+
+    const gateway = new ZoteroGateway();
+    let caught: unknown;
+    try {
+      await gateway.replaceCurrentNote({
+        request: {
+          conversationKey: 9,
+          mode: "agent",
+          userText: "Update the note",
+          activeNoteContext: {
+            noteId: 57,
+            title: "Changed Note",
+            noteKind: "standalone",
+            noteText: "# Overview\n\nOriginal body",
+          },
+        },
+        content: "# Overview\n\nUpdated body",
+        expectedOriginalHtml: "<h1>Overview</h1><p>Original body</p>",
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    assert.instanceOf(caught, Error);
+    assert.match(
+      (caught as Error).message,
+      /active note changed before this edit was applied/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- preserve Zotero `<h1>` through `<h6>` levels as Markdown heading markers in the model-facing note snapshot
- compare current and expected note pre-images with the same heading-aware conversion to avoid false concurrent-edit conflicts
- reject accidental heading demotion during full-note edits before the review card is created
- allow heading restructuring only through the explicit `allowHeadingChanges` opt-in
- clarify that `content` in edit mode replaces the complete note and must retain unchanged heading markers

## Root cause

Zotero returns note content as HTML. `readNoteSnapshot()` previously passed that HTML through `stripNoteHtml()`, which retained heading text but discarded the `<h1>` / `<h2>` structure. The model therefore received ordinary text lines and could not preserve their levels during a full-note rewrite.

This addresses the format-loss path reported in #101. It is separate from #349, which concerns the Markdown renderer's heading offset when initially writing content to a Zotero note.

## Tests

- `npm run typecheck`
- `npm run check:cycles`
- Prettier and ESLint on the changed files
- targeted note snapshot and edit-tool tests: 59 passing
- complete unit suite: 3911 passing, 1 pending
- `npm run build`

The Zotero workflow harness was not run locally because it requires an explicitly configured isolated `ZOTERO_PLUGIN_ZOTERO_BIN_PATH`.

Addresses #101
