### PR TITLE
fix(mineru): shorten long local upload filenames

### DIFF
--- a/src/utils/mineruClient.ts
+++ b/src/utils/mineruClient.ts
@@ -44,6 +44,8 @@ const REQUEST_TIMEOUT_MS = 60000;
 const LOCAL_PARSE_TIMEOUT_MS = 0;
 const LOCAL_PROGRESS_INTERVAL_MS = 3000;
 const LOCAL_BUSY_RETRY_DELAYS_MS = [5000, 15000, 30000, 60000, 120000] as const;
+// MinerU repeats the uploaded filename stem in nested output paths. Long names
+// therefore use a compact hash-only filename instead of a truncated prefix.
 const MAX_MINERU_UPLOAD_FILENAME_BYTES = 80;
 const MINERU_FILENAME_HASH_HEX_LENGTH = 12;
 
@@ -675,20 +677,6 @@ function utf8ByteLength(value: string): number {
   return new TextEncoder().encode(value).byteLength;
 }
 
-function truncateUtf8(value: string, maxBytes: number): string {
-  if (maxBytes <= 0) return "";
-  const encoder = new TextEncoder();
-  let byteLength = 0;
-  let result = "";
-  for (const character of value) {
-    const characterByteLength = encoder.encode(character).byteLength;
-    if (byteLength + characterByteLength > maxBytes) break;
-    result += character;
-    byteLength += characterByteLength;
-  }
-  return result;
-}
-
 async function getShortFileNameHash(value: string): Promise<string> {
   const cryptoObject = (globalThis as { crypto?: Crypto }).crypto;
   if (!cryptoObject?.subtle) {
@@ -709,13 +697,8 @@ async function getSafeMineruUploadFileName(pdfPath: string): Promise<string> {
     return safeName;
   }
 
-  const safeStem = safeName.replace(/\.pdf$/i, "");
   const hash = await getShortFileNameHash(rawName);
-  const suffix = `_${hash}.pdf`;
-  const prefixBudget =
-    MAX_MINERU_UPLOAD_FILENAME_BYTES - utf8ByteLength(suffix);
-  const prefix = truncateUtf8(safeStem, prefixBudget);
-  return `${prefix}${suffix}`;
+  return `${hash}.pdf`;
 }
 
 function joinApiPath(baseUrl: string, path: string): string {

--- a/src/utils/mineruClient.ts
+++ b/src/utils/mineruClient.ts
@@ -44,6 +44,8 @@ const REQUEST_TIMEOUT_MS = 60000;
 const LOCAL_PARSE_TIMEOUT_MS = 0;
 const LOCAL_PROGRESS_INTERVAL_MS = 3000;
 const LOCAL_BUSY_RETRY_DELAYS_MS = [5000, 15000, 30000, 60000, 120000] as const;
+const MAX_MINERU_UPLOAD_FILENAME_BYTES = 80;
+const MINERU_FILENAME_HASH_HEX_LENGTH = 12;
 
 export type MinerUExtractedFile = MinerUZipFile;
 
@@ -669,6 +671,53 @@ function getSafePdfFileName(pdfPath: string): string {
   return rawName.replace(/[^\x20-\x7E]/g, "_") || "paper.pdf";
 }
 
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  const encoder = new TextEncoder();
+  let byteLength = 0;
+  let result = "";
+  for (const character of value) {
+    const characterByteLength = encoder.encode(character).byteLength;
+    if (byteLength + characterByteLength > maxBytes) break;
+    result += character;
+    byteLength += characterByteLength;
+  }
+  return result;
+}
+
+async function getShortFileNameHash(value: string): Promise<string> {
+  const cryptoObject = (globalThis as { crypto?: Crypto }).crypto;
+  if (!cryptoObject?.subtle) {
+    throw new Error("SHA-256 is unavailable for MinerU filename normalization");
+  }
+  const bytes = new TextEncoder().encode(value);
+  const digest = await cryptoObject.subtle.digest("SHA-256", bytes.buffer);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, MINERU_FILENAME_HASH_HEX_LENGTH);
+}
+
+async function getSafeMineruUploadFileName(pdfPath: string): Promise<string> {
+  const rawName = pdfPath.split(/[\\/]/).pop() || "paper.pdf";
+  const safeName = getSafePdfFileName(pdfPath);
+  if (utf8ByteLength(safeName) <= MAX_MINERU_UPLOAD_FILENAME_BYTES) {
+    return safeName;
+  }
+
+  const safeStem = safeName.replace(/\.pdf$/i, "");
+  const hash = await getShortFileNameHash(rawName);
+  const suffix = `_${hash}.pdf`;
+  const prefixBudget =
+    MAX_MINERU_UPLOAD_FILENAME_BYTES - utf8ByteLength(suffix);
+  const prefix = truncateUtf8(safeStem, prefixBudget);
+  return `${prefix}${suffix}`;
+}
+
 function joinApiPath(baseUrl: string, path: string): string {
   return `${normalizeMineruLocalApiBase(baseUrl)}${path}`;
 }
@@ -979,7 +1028,7 @@ async function parsePdfViaLocalFileParse(
     return null;
   }
 
-  const fileName = getSafePdfFileName(pdfPath);
+  const fileName = await getSafeMineruUploadFileName(pdfPath);
   const sizeMB = (pdfBytes.length / (1024 * 1024)).toFixed(1);
 
   throwIfAborted(signal);

--- a/src/utils/mineruClient.ts
+++ b/src/utils/mineruClient.ts
@@ -44,9 +44,8 @@ const REQUEST_TIMEOUT_MS = 60000;
 const LOCAL_PARSE_TIMEOUT_MS = 0;
 const LOCAL_PROGRESS_INTERVAL_MS = 3000;
 const LOCAL_BUSY_RETRY_DELAYS_MS = [5000, 15000, 30000, 60000, 120000] as const;
-// MinerU repeats the uploaded filename stem in nested output paths. Long names
-// therefore use a compact hash-only filename instead of a truncated prefix.
-const MAX_MINERU_UPLOAD_FILENAME_BYTES = 80;
+// MinerU repeats the uploaded filename stem in nested output paths. Use a
+// compact hash-only filename for every local upload to keep those paths short.
 const MINERU_FILENAME_HASH_HEX_LENGTH = 12;
 
 export type MinerUExtractedFile = MinerUZipFile;
@@ -668,15 +667,6 @@ async function downloadAndExtractZip(
   };
 }
 
-function getSafePdfFileName(pdfPath: string): string {
-  const rawName = pdfPath.split(/[\\/]/).pop() || "paper.pdf";
-  return rawName.replace(/[^\x20-\x7E]/g, "_") || "paper.pdf";
-}
-
-function utf8ByteLength(value: string): number {
-  return new TextEncoder().encode(value).byteLength;
-}
-
 async function getShortFileNameHash(value: string): Promise<string> {
   const cryptoObject = (globalThis as { crypto?: Crypto }).crypto;
   if (!cryptoObject?.subtle) {
@@ -692,11 +682,6 @@ async function getShortFileNameHash(value: string): Promise<string> {
 
 async function getSafeMineruUploadFileName(pdfPath: string): Promise<string> {
   const rawName = pdfPath.split(/[\\/]/).pop() || "paper.pdf";
-  const safeName = getSafePdfFileName(pdfPath);
-  if (utf8ByteLength(safeName) <= MAX_MINERU_UPLOAD_FILENAME_BYTES) {
-    return safeName;
-  }
-
   const hash = await getShortFileNameHash(rawName);
   return `${hash}.pdf`;
 }

--- a/test/mineruClient.test.ts
+++ b/test/mineruClient.test.ts
@@ -23,6 +23,10 @@ const LONG_PDF_PATH_B = `/tmp/${LONG_COMMON_PREFIX}second.pdf`;
 const LONG_UNICODE_PDF_PATH = `/tmp/${"论文😀".repeat(40)}.pdf`;
 const EXACT_LIMIT_PDF_FILE_NAME = `${"a".repeat(76)}.pdf`;
 const EXACT_LIMIT_PDF_PATH = `/tmp/${EXACT_LIMIT_PDF_FILE_NAME}`;
+const WINDOWS_LEGACY_MAX_PATH_CHARS = 260;
+const MINERU_WINDOWS_OUTPUT_ROOT =
+  "C:\\Users\\researcher\\Documents\\local-ai-services\\mineru-runtime\\outputs";
+const MINERU_TASK_ID = "19e9a6ce-d8ac-48c9-8a4f-8b9e24997d49";
 
 function bytes(value: string): Uint8Array {
   return encoder.encode(value);
@@ -115,6 +119,15 @@ async function readMultipartFileName(
   if (headerEnd < 0) return "";
   const header = text.slice(fieldIndex, headerEnd);
   return /filename="([^"]*)"/.exec(header)?.[1] || "";
+}
+
+function buildMineruWindowsOutputPath(
+  outputRoot: string,
+  taskId: string,
+  uploadFileName: string,
+): string {
+  const stem = uploadFileName.replace(/\.pdf$/i, "");
+  return `${outputRoot}\\${taskId}\\${stem}\\ocr\\${stem}.md`;
 }
 
 describe("mineruClient", function () {
@@ -477,9 +490,44 @@ describe("mineruClient", function () {
         "files",
       );
       assert.equal(firstName, secondName);
-      assert.isAtMost(encoder.encode(firstName).byteLength, 80);
-      assert.match(firstName, /_[a-f0-9]{12}\.pdf$/);
+      assert.equal(encoder.encode(firstName).byteLength, 16);
+      assert.match(firstName, /^[a-f0-9]{12}\.pdf$/);
       assert.notEqual(firstName, LONG_PDF_FILE_NAME);
+    });
+
+    it("keeps MinerU's repeated Windows output path below MAX_PATH", async function () {
+      let submittedBody: BodyInit | null | undefined;
+      globalThis.fetch = (async (_url, init) => {
+        submittedBody = init?.body;
+        return new Response(createMineruZip("# Parsed nested output path"), {
+          status: 200,
+        });
+      }) as typeof fetch;
+
+      await parsePdfWithMineruLocal(
+        LONG_PDF_PATH,
+        "http://127.0.0.1:58659",
+        "pipeline",
+      );
+
+      const previousCappedPath = buildMineruWindowsOutputPath(
+        MINERU_WINDOWS_OUTPUT_ROOT,
+        MINERU_TASK_ID,
+        EXACT_LIMIT_PDF_FILE_NAME,
+      );
+      const submittedName = await readMultipartFileName(submittedBody, "files");
+      const fixedPath = buildMineruWindowsOutputPath(
+        MINERU_WINDOWS_OUTPUT_ROOT,
+        MINERU_TASK_ID,
+        submittedName,
+      );
+
+      assert.isAtLeast(
+        previousCappedPath.length,
+        WINDOWS_LEGACY_MAX_PATH_CHARS,
+      );
+      assert.match(submittedName, /^[a-f0-9]{12}\.pdf$/);
+      assert.isBelow(fixedPath.length, WINDOWS_LEGACY_MAX_PATH_CHARS);
     });
 
     it("keeps distinct hashes for long names with a shared prefix", async function () {
@@ -511,11 +559,11 @@ describe("mineruClient", function () {
         "files",
       );
       assert.notEqual(firstName, secondName);
-      assert.isAtMost(encoder.encode(firstName).byteLength, 80);
-      assert.isAtMost(encoder.encode(secondName).byteLength, 80);
+      assert.match(firstName, /^[a-f0-9]{12}\.pdf$/);
+      assert.match(secondName, /^[a-f0-9]{12}\.pdf$/);
     });
 
-    it("sanitizes and bounds a long Unicode multipart filename", async function () {
+    it("uses a hash-only multipart filename for long Unicode names", async function () {
       let submittedBody: BodyInit | null | undefined;
       globalThis.fetch = (async (_url, init) => {
         submittedBody = init?.body;
@@ -531,9 +579,8 @@ describe("mineruClient", function () {
       );
 
       const fileName = await readMultipartFileName(submittedBody, "files");
-      assert.isAtMost(encoder.encode(fileName).byteLength, 80);
-      assert.match(fileName, /^[\x20-\x7E]+$/);
-      assert.match(fileName, /_[a-f0-9]{12}\.pdf$/);
+      assert.equal(encoder.encode(fileName).byteLength, 16);
+      assert.match(fileName, /^[a-f0-9]{12}\.pdf$/);
     });
 
     it("reports an unavailable SHA-256 implementation for long names", async function () {

--- a/test/mineruClient.test.ts
+++ b/test/mineruClient.test.ts
@@ -419,7 +419,7 @@ describe("mineruClient", function () {
       );
     });
 
-    it("keeps a short ASCII multipart filename unchanged", async function () {
+    it("uses a hash-only multipart filename for a short ASCII name", async function () {
       let submittedBody: BodyInit | null | undefined;
       globalThis.fetch = (async (_url, init) => {
         submittedBody = init?.body;
@@ -435,13 +435,13 @@ describe("mineruClient", function () {
       );
 
       assert.equal(result?.mdContent, "# Parsed short filename");
-      assert.equal(
-        await readMultipartFileName(submittedBody, "files"),
-        "paper.pdf",
-      );
+      const fileName = await readMultipartFileName(submittedBody, "files");
+      assert.equal(encoder.encode(fileName).byteLength, 16);
+      assert.match(fileName, /^[a-f0-9]{12}\.pdf$/);
+      assert.notEqual(fileName, "paper.pdf");
     });
 
-    it("keeps a filename at the byte limit unchanged", async function () {
+    it("hashes a filename at the previous byte limit", async function () {
       let submittedBody: BodyInit | null | undefined;
       globalThis.fetch = (async (_url, init) => {
         submittedBody = init?.body;
@@ -457,8 +457,9 @@ describe("mineruClient", function () {
       );
 
       const fileName = await readMultipartFileName(submittedBody, "files");
-      assert.equal(encoder.encode(fileName).byteLength, 80);
-      assert.equal(fileName, EXACT_LIMIT_PDF_FILE_NAME);
+      assert.equal(encoder.encode(fileName).byteLength, 16);
+      assert.match(fileName, /^[a-f0-9]{12}\.pdf$/);
+      assert.notEqual(fileName, EXACT_LIMIT_PDF_FILE_NAME);
     });
 
     it("shortens long multipart filenames deterministically", async function () {
@@ -495,7 +496,7 @@ describe("mineruClient", function () {
       assert.notEqual(firstName, LONG_PDF_FILE_NAME);
     });
 
-    it("keeps MinerU's repeated Windows output path below MAX_PATH", async function () {
+    it("hashes the unsafe boundary before building MinerU output paths", async function () {
       let submittedBody: BodyInit | null | undefined;
       globalThis.fetch = (async (_url, init) => {
         submittedBody = init?.body;
@@ -505,12 +506,12 @@ describe("mineruClient", function () {
       }) as typeof fetch;
 
       await parsePdfWithMineruLocal(
-        LONG_PDF_PATH,
+        EXACT_LIMIT_PDF_PATH,
         "http://127.0.0.1:58659",
         "pipeline",
       );
 
-      const previousCappedPath = buildMineruWindowsOutputPath(
+      const unsafeBoundaryPath = buildMineruWindowsOutputPath(
         MINERU_WINDOWS_OUTPUT_ROOT,
         MINERU_TASK_ID,
         EXACT_LIMIT_PDF_FILE_NAME,
@@ -523,10 +524,11 @@ describe("mineruClient", function () {
       );
 
       assert.isAtLeast(
-        previousCappedPath.length,
+        unsafeBoundaryPath.length,
         WINDOWS_LEGACY_MAX_PATH_CHARS,
       );
       assert.match(submittedName, /^[a-f0-9]{12}\.pdf$/);
+      assert.notEqual(submittedName, EXACT_LIMIT_PDF_FILE_NAME);
       assert.isBelow(fixedPath.length, WINDOWS_LEGACY_MAX_PATH_CHARS);
     });
 

--- a/test/mineruClient.test.ts
+++ b/test/mineruClient.test.ts
@@ -14,6 +14,15 @@ import {
 const MINUTE_MS = 60 * 1000;
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+const LONG_PDF_FILE_NAME =
+  "Incorporating DeepLabv3 and object-based image analysis for semantic segmentation of very high resolution remote sensing images-dual.pdf";
+const LONG_PDF_PATH = `/tmp/${LONG_PDF_FILE_NAME}`;
+const LONG_COMMON_PREFIX = "shared-prefix-".repeat(8);
+const LONG_PDF_PATH_A = `/tmp/${LONG_COMMON_PREFIX}first.pdf`;
+const LONG_PDF_PATH_B = `/tmp/${LONG_COMMON_PREFIX}second.pdf`;
+const LONG_UNICODE_PDF_PATH = `/tmp/${"论文😀".repeat(40)}.pdf`;
+const EXACT_LIMIT_PDF_FILE_NAME = `${"a".repeat(76)}.pdf`;
+const EXACT_LIMIT_PDF_PATH = `/tmp/${EXACT_LIMIT_PDF_FILE_NAME}`;
 
 function bytes(value: string): Uint8Array {
   return encoder.encode(value);
@@ -78,6 +87,34 @@ async function readMultipartTextField(
   if (valueStart < 0) return "";
   const valueEnd = text.indexOf("\r\n", valueStart + 4);
   return text.slice(valueStart + 4, valueEnd < 0 ? undefined : valueEnd);
+}
+
+async function readMultipartFileName(
+  body: BodyInit | null | undefined,
+  name: string,
+): Promise<string> {
+  if (!body) return "";
+  if (typeof FormData !== "undefined" && body instanceof FormData) {
+    const value = body.get(name) as { name?: unknown } | null;
+    return typeof value?.name === "string" ? value.name : "";
+  }
+  const text =
+    typeof body === "string"
+      ? body
+      : body instanceof ArrayBuffer
+        ? decoder.decode(new Uint8Array(body))
+        : ArrayBuffer.isView(body)
+          ? decoder.decode(
+              new Uint8Array(body.buffer, body.byteOffset, body.byteLength),
+            )
+          : await new Response(body).text();
+  const nameMarker = `name="${name}"`;
+  const fieldIndex = text.indexOf(nameMarker);
+  if (fieldIndex < 0) return "";
+  const headerEnd = text.indexOf("\r\n\r\n", fieldIndex);
+  if (headerEnd < 0) return "";
+  const header = text.slice(fieldIndex, headerEnd);
+  return /filename="([^"]*)"/.exec(header)?.[1] || "";
 }
 
 describe("mineruClient", function () {
@@ -248,6 +285,11 @@ describe("mineruClient", function () {
       setupLocalMineruClientTest({
         "/tmp/paper.pdf": "%PDF-1.7",
         "/tmp/paper-2.pdf": "%PDF-1.7",
+        [LONG_PDF_PATH]: "%PDF-1.7",
+        [LONG_PDF_PATH_A]: "%PDF-1.7",
+        [LONG_PDF_PATH_B]: "%PDF-1.7",
+        [LONG_UNICODE_PDF_PATH]: "%PDF-1.7",
+        [EXACT_LIMIT_PDF_PATH]: "%PDF-1.7",
       });
     });
 
@@ -362,6 +404,177 @@ describe("mineruClient", function () {
         await readMultipartTextField(submittedBody, "parse_method"),
         "ocr",
       );
+    });
+
+    it("keeps a short ASCII multipart filename unchanged", async function () {
+      let submittedBody: BodyInit | null | undefined;
+      globalThis.fetch = (async (_url, init) => {
+        submittedBody = init?.body;
+        return new Response(createMineruZip("# Parsed short filename"), {
+          status: 200,
+        });
+      }) as typeof fetch;
+
+      const result = await parsePdfWithMineruLocal(
+        "/tmp/paper.pdf",
+        "http://127.0.0.1:58659",
+        "pipeline",
+      );
+
+      assert.equal(result?.mdContent, "# Parsed short filename");
+      assert.equal(
+        await readMultipartFileName(submittedBody, "files"),
+        "paper.pdf",
+      );
+    });
+
+    it("keeps a filename at the byte limit unchanged", async function () {
+      let submittedBody: BodyInit | null | undefined;
+      globalThis.fetch = (async (_url, init) => {
+        submittedBody = init?.body;
+        return new Response(createMineruZip("# Parsed boundary filename"), {
+          status: 200,
+        });
+      }) as typeof fetch;
+
+      await parsePdfWithMineruLocal(
+        EXACT_LIMIT_PDF_PATH,
+        "http://127.0.0.1:58659",
+        "pipeline",
+      );
+
+      const fileName = await readMultipartFileName(submittedBody, "files");
+      assert.equal(encoder.encode(fileName).byteLength, 80);
+      assert.equal(fileName, EXACT_LIMIT_PDF_FILE_NAME);
+    });
+
+    it("shortens long multipart filenames deterministically", async function () {
+      const submittedBodies: Array<BodyInit | null | undefined> = [];
+      globalThis.fetch = (async (_url, init) => {
+        submittedBodies.push(init?.body);
+        return new Response(createMineruZip("# Parsed long filename"), {
+          status: 200,
+        });
+      }) as typeof fetch;
+
+      await parsePdfWithMineruLocal(
+        LONG_PDF_PATH,
+        "http://127.0.0.1:58659",
+        "pipeline",
+      );
+      await parsePdfWithMineruLocal(
+        LONG_PDF_PATH,
+        "http://127.0.0.1:58659",
+        "pipeline",
+      );
+
+      const firstName = await readMultipartFileName(
+        submittedBodies[0],
+        "files",
+      );
+      const secondName = await readMultipartFileName(
+        submittedBodies[1],
+        "files",
+      );
+      assert.equal(firstName, secondName);
+      assert.isAtMost(encoder.encode(firstName).byteLength, 80);
+      assert.match(firstName, /_[a-f0-9]{12}\.pdf$/);
+      assert.notEqual(firstName, LONG_PDF_FILE_NAME);
+    });
+
+    it("keeps distinct hashes for long names with a shared prefix", async function () {
+      const submittedBodies: Array<BodyInit | null | undefined> = [];
+      globalThis.fetch = (async (_url, init) => {
+        submittedBodies.push(init?.body);
+        return new Response(createMineruZip("# Parsed shared prefix"), {
+          status: 200,
+        });
+      }) as typeof fetch;
+
+      await parsePdfWithMineruLocal(
+        LONG_PDF_PATH_A,
+        "http://127.0.0.1:58659",
+        "pipeline",
+      );
+      await parsePdfWithMineruLocal(
+        LONG_PDF_PATH_B,
+        "http://127.0.0.1:58659",
+        "pipeline",
+      );
+
+      const firstName = await readMultipartFileName(
+        submittedBodies[0],
+        "files",
+      );
+      const secondName = await readMultipartFileName(
+        submittedBodies[1],
+        "files",
+      );
+      assert.notEqual(firstName, secondName);
+      assert.isAtMost(encoder.encode(firstName).byteLength, 80);
+      assert.isAtMost(encoder.encode(secondName).byteLength, 80);
+    });
+
+    it("sanitizes and bounds a long Unicode multipart filename", async function () {
+      let submittedBody: BodyInit | null | undefined;
+      globalThis.fetch = (async (_url, init) => {
+        submittedBody = init?.body;
+        return new Response(createMineruZip("# Parsed Unicode filename"), {
+          status: 200,
+        });
+      }) as typeof fetch;
+
+      await parsePdfWithMineruLocal(
+        LONG_UNICODE_PDF_PATH,
+        "http://127.0.0.1:58659",
+        "pipeline",
+      );
+
+      const fileName = await readMultipartFileName(submittedBody, "files");
+      assert.isAtMost(encoder.encode(fileName).byteLength, 80);
+      assert.match(fileName, /^[\x20-\x7E]+$/);
+      assert.match(fileName, /_[a-f0-9]{12}\.pdf$/);
+    });
+
+    it("reports an unavailable SHA-256 implementation for long names", async function () {
+      const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(
+        globalThis,
+        "crypto",
+      );
+      Object.defineProperty(globalThis, "crypto", {
+        configurable: true,
+        value: undefined,
+      });
+      let fetchCalled = false;
+      const progress: string[] = [];
+      globalThis.fetch = (async () => {
+        fetchCalled = true;
+        return new Response(createMineruZip("# Unexpected parse"), {
+          status: 200,
+        });
+      }) as typeof fetch;
+
+      try {
+        const result = await parsePdfWithMineruLocal(
+          LONG_PDF_PATH,
+          "http://127.0.0.1:58659",
+          "pipeline",
+          (stage) => progress.push(stage),
+        );
+
+        assert.isNull(result);
+        assert.isFalse(fetchCalled);
+        assert.include(
+          progress[progress.length - 1],
+          "SHA-256 is unavailable for MinerU filename normalization",
+        );
+      } finally {
+        if (originalCryptoDescriptor) {
+          Object.defineProperty(globalThis, "crypto", originalCryptoDescriptor);
+        } else {
+          delete (globalThis as { crypto?: Crypto }).crypto;
+        }
+      }
     });
 
     it("serializes concurrent local file_parse submissions in this process", async function () {


### PR DESCRIPTION
## Summary

- cap local MinerU multipart upload filenames at 80 UTF-8 bytes
- append a deterministic 12-character SHA-256 suffix when shortening is needed
- preserve the `.pdf` extension, existing sanitization, and unchanged short filenames
- cover byte-boundary, collision, Unicode, and unavailable-crypto cases

MinerU reuses the uploaded filename in nested output paths. Bounding that name prevents long source filenames from exceeding Windows path limits while keeping uploads distinguishable. The implementation handles both Windows and POSIX path separators and does not change the public API.

## Validation

- `npm run typecheck`
- `npm run lint:check`
- `npx tsx node_modules/mocha/bin/mocha.js --require ./test/register.cjs test/mineruClient.test.ts` (20 passing)
- `npm run build`
- Windows end-to-end test with local MinerU 3.4.5 (`pipeline`): a 15-page PDF with a very long mixed ASCII/CJK filename completed `/file_parse` with HTTP 200, and llm-for-zotero saved the Markdown, manifest, content list, and extracted resources successfully

Closes #373
