### PR TITLE
fix(agent): normalize Kimi anyOf tool schemas

### DIFF
--- a/src/agent/model/openaiCompatible.ts
+++ b/src/agent/model/openaiCompatible.ts
@@ -7,6 +7,7 @@ import {
   resolveRequestAuthState,
 } from "../../utils/llmClient";
 import { normalizeTemperature } from "../../utils/normalization";
+import { detectProviderPreset } from "../../utils/providerPresets";
 import { resolveProviderTransportEndpoint } from "../../utils/providerTransport";
 import { extractContextCacheUsage } from "../../contextCache/manager";
 import type {
@@ -15,6 +16,7 @@ import type {
   AgentModelStep,
   AgentRuntimeRequest,
   AgentToolCall,
+  ToolSpec,
 } from "../types";
 import type { AgentModelAdapter, AgentStepParams } from "./adapter";
 import { buildAgentModelCapabilities } from "./contentCapabilities";
@@ -81,6 +83,60 @@ function isToolCapableApiBase(request: AgentRuntimeRequest): boolean {
   if (!apiBase) return false;
   if (request.authMode === "codex_auth") return false;
   return true;
+}
+
+function normalizeKimiJsonSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map((entry) => normalizeKimiJsonSchema(entry));
+  }
+  if (!schema || typeof schema !== "object") return schema;
+
+  const source = schema as Record<string, unknown>;
+  const normalized = Object.fromEntries(
+    Object.entries(source).map(([key, value]) => [
+      key,
+      normalizeKimiJsonSchema(value),
+    ]),
+  ) as Record<string, unknown>;
+
+  if (source.type !== undefined && Array.isArray(source.anyOf)) {
+    const parentType = normalizeKimiJsonSchema(source.type);
+    delete normalized.type;
+    normalized.anyOf = source.anyOf.map((variant) => {
+      const normalizedVariant = normalizeKimiJsonSchema(variant);
+      if (
+        !normalizedVariant ||
+        typeof normalizedVariant !== "object" ||
+        Array.isArray(normalizedVariant) ||
+        "type" in normalizedVariant
+      ) {
+        return normalizedVariant;
+      }
+      return {
+        type: parentType,
+        ...normalizedVariant,
+      };
+    });
+  }
+
+  return normalized;
+}
+
+function buildProviderFunctionTools(
+  request: AgentRuntimeRequest,
+  tools: ToolSpec[],
+) {
+  const serializedTools = buildOpenAIFunctionTools(tools);
+  if (detectProviderPreset(request.apiBase || "") !== "kimi") {
+    return serializedTools;
+  }
+  return serializedTools.map((tool) => ({
+    ...tool,
+    function: {
+      ...tool.function,
+      parameters: normalizeKimiJsonSchema(tool.function.parameters) as object,
+    },
+  }));
 }
 
 function hasPdfFileRef(message: AgentModelMessage): boolean {
@@ -427,7 +483,7 @@ export class OpenAIChatCompatAgentAdapter implements AgentModelAdapter {
           model: request.model,
           messages: resolvedMessages,
           ...buildPromptCachePayloadHints(request.contextCache),
-          tools: buildOpenAIFunctionTools(params.tools),
+          tools: buildProviderFunctionTools(request, params.tools),
           tool_choice: "auto",
           stream: true,
           stream_options: { include_usage: true },

--- a/src/agent/model/openaiCompatible.ts
+++ b/src/agent/model/openaiCompatible.ts
@@ -85,41 +85,212 @@ function isToolCapableApiBase(request: AgentRuntimeRequest): boolean {
   return true;
 }
 
-function normalizeKimiJsonSchema(schema: unknown): unknown {
-  if (Array.isArray(schema)) {
-    return schema.map((entry) => normalizeKimiJsonSchema(entry));
-  }
-  if (!schema || typeof schema !== "object") return schema;
+const KIMI_JSON_SCHEMA_KEYWORDS = new Set([
+  "$id",
+  "$defs",
+  "$ref",
+  "type",
+  "properties",
+  "required",
+  "additionalProperties",
+  "anyOf",
+  "items",
+  "enum",
+  "maximum",
+  "minimum",
+  "maxLength",
+  "minLength",
+  "maxItems",
+  "minItems",
+  "title",
+  "description",
+  "default",
+]);
 
-  const source = schema as Record<string, unknown>;
-  const normalized = Object.fromEntries(
-    Object.entries(source).map(([key, value]) => [
+const KIMI_JSON_TYPES = [
+  "null",
+  "boolean",
+  "object",
+  "array",
+  "number",
+  "integer",
+  "string",
+] as const;
+
+function cloneJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((entry) => cloneJsonValue(entry));
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
       key,
-      normalizeKimiJsonSchema(value),
+      cloneJsonValue(entry),
     ]),
-  ) as Record<string, unknown>;
+  );
+}
 
-  if (source.type !== undefined && Array.isArray(source.anyOf)) {
-    const parentType = normalizeKimiJsonSchema(source.type);
-    delete normalized.type;
-    normalized.anyOf = source.anyOf.map((variant) => {
-      const normalizedVariant = normalizeKimiJsonSchema(variant);
-      if (
-        !normalizedVariant ||
-        typeof normalizedVariant !== "object" ||
-        Array.isArray(normalizedVariant) ||
-        "type" in normalizedVariant
-      ) {
-        return normalizedVariant;
-      }
-      return {
-        type: parentType,
-        ...normalizedVariant,
-      };
-    });
+function mergeKimiAnyOfBranch(
+  constraints: Record<string, unknown>,
+  variant: unknown,
+): unknown {
+  if (!variant || typeof variant !== "object" || Array.isArray(variant)) {
+    return variant;
+  }
+  const branch = variant as Record<string, unknown>;
+  const merged = {
+    ...constraints,
+    ...branch,
+  };
+  if (
+    constraints.properties &&
+    typeof constraints.properties === "object" &&
+    !Array.isArray(constraints.properties) &&
+    branch.properties &&
+    typeof branch.properties === "object" &&
+    !Array.isArray(branch.properties)
+  ) {
+    merged.properties = {
+      ...(constraints.properties as Record<string, unknown>),
+      ...(branch.properties as Record<string, unknown>),
+    };
+  }
+  if (Array.isArray(constraints.required) && Array.isArray(branch.required)) {
+    merged.required = Array.from(
+      new Set([...constraints.required, ...branch.required]),
+    );
+  }
+  return merged;
+}
+
+function inferKimiJsonSchemaType(
+  schema: Record<string, unknown>,
+): (typeof KIMI_JSON_TYPES)[number] | undefined {
+  if (
+    schema.properties !== undefined ||
+    schema.required !== undefined ||
+    schema.additionalProperties !== undefined
+  ) {
+    return "object";
+  }
+  if (
+    schema.items !== undefined ||
+    schema.minItems !== undefined ||
+    schema.maxItems !== undefined
+  ) {
+    return "array";
+  }
+  if (schema.minLength !== undefined || schema.maxLength !== undefined) {
+    return "string";
+  }
+  if (schema.minimum !== undefined || schema.maximum !== undefined) {
+    return "number";
+  }
+  if (Array.isArray(schema.enum) && schema.enum.length) {
+    const types = new Set(
+      schema.enum.map((value) =>
+        value === null
+          ? "null"
+          : typeof value === "number"
+            ? "number"
+            : typeof value,
+      ),
+    );
+    const [type] = types;
+    if (
+      types.size === 1 &&
+      KIMI_JSON_TYPES.includes(type as (typeof KIMI_JSON_TYPES)[number])
+    ) {
+      return type as (typeof KIMI_JSON_TYPES)[number];
+    }
+  }
+  return undefined;
+}
+
+function normalizeKimiJsonSchema(schema: unknown, isRoot = true): unknown {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return cloneJsonValue(schema);
   }
 
-  return normalized;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(
+    schema as Record<string, unknown>,
+  )) {
+    if (!KIMI_JSON_SCHEMA_KEYWORDS.has(key)) continue;
+    if ((key === "$id" || key === "$defs") && !isRoot) continue;
+    if (key === "properties" || key === "$defs") {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        normalized[key] = cloneJsonValue(value);
+        continue;
+      }
+      normalized[key] = Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(
+          ([name, childSchema]) => [
+            name,
+            normalizeKimiJsonSchema(childSchema, false),
+          ],
+        ),
+      );
+      continue;
+    }
+    if (key === "anyOf" && Array.isArray(value)) {
+      normalized.anyOf = value.map((variant) =>
+        normalizeKimiJsonSchema(variant, false),
+      );
+      continue;
+    }
+    if (
+      key === "items" ||
+      (key === "additionalProperties" &&
+        value !== null &&
+        typeof value === "object")
+    ) {
+      normalized[key] = normalizeKimiJsonSchema(value, false);
+      continue;
+    }
+    normalized[key] = cloneJsonValue(value);
+  }
+
+  if (
+    !Array.isArray(normalized.anyOf) &&
+    normalized.type === undefined &&
+    normalized.$ref === undefined
+  ) {
+    const inferredType = inferKimiJsonSchemaType(normalized);
+    if (inferredType) return { type: inferredType, ...normalized };
+    const { description, title } = normalized;
+    return {
+      ...(description !== undefined ? { description } : {}),
+      ...(title !== undefined ? { title } : {}),
+      anyOf: KIMI_JSON_TYPES.map((type) => ({ type })),
+    };
+  }
+
+  if (!Array.isArray(normalized.anyOf)) return normalized;
+
+  const outer: Record<string, unknown> = {};
+  const constraints: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(normalized)) {
+    if (key === "anyOf") continue;
+    if (
+      key === "description" ||
+      key === "title" ||
+      key === "$id" ||
+      key === "$defs"
+    ) {
+      outer[key] = value;
+    } else {
+      constraints[key] = value;
+    }
+  }
+
+  return {
+    ...outer,
+    anyOf: normalized.anyOf.map((variant) =>
+      normalizeKimiJsonSchema(
+        mergeKimiAnyOfBranch(constraints, variant),
+        false,
+      ),
+    ),
+  };
 }
 
 function buildProviderFunctionTools(

--- a/src/agent/tools/read/queryLibrary.ts
+++ b/src/agent/tools/read/queryLibrary.ts
@@ -14,6 +14,10 @@ import type {
   ZoteroGateway,
 } from "../../services/zoteroGateway";
 import { fail, normalizePositiveInt, ok, validateObject } from "../shared";
+import {
+  SEARCH_CONDITION_SCHEMA,
+  parseSearchCondition,
+} from "../searchConditions";
 
 type QueryLibraryInput = {
   entity: QueryLibraryEntity;
@@ -57,37 +61,13 @@ function normalizeInclude(value: unknown): QueryLibraryInclude[] | undefined {
   return includes.length ? Array.from(new Set(includes)) : undefined;
 }
 
-/**
- * Reads `conditions[]` without validating the vocabulary.
- *
- * Whether a condition and operator actually pair up is Zotero's question, not
- * ours -- `Zotero.SearchConditions` is the authority and answers it at
- * execution time with the list of valid operators. Duplicating that table
- * here is how the nine hand-written filters came to exist in the first place.
- */
 function normalizeConditions(
   value: unknown,
 ): AgentSearchCondition[] | undefined {
-  if (!Array.isArray(value) || !value.length) return undefined;
-  const conditions: AgentSearchCondition[] = [];
-  for (const entry of value) {
-    if (!validateObject<Record<string, unknown>>(entry)) continue;
-    const condition =
-      typeof entry.condition === "string" ? entry.condition.trim() : "";
-    const operator =
-      typeof entry.operator === "string" ? entry.operator.trim() : "";
-    if (!condition) continue;
-    conditions.push({
-      condition,
-      operator,
-      value:
-        typeof entry.value === "string" || typeof entry.value === "number"
-          ? entry.value
-          : undefined,
-      mode: typeof entry.mode === "string" ? entry.mode.trim() : undefined,
-      required: entry.required === true ? true : undefined,
-    });
-  }
+  if (!Array.isArray(value)) return undefined;
+  const conditions = value
+    .map(parseSearchCondition)
+    .filter((entry): entry is AgentSearchCondition => Boolean(entry));
   return conditions.length ? conditions : undefined;
 }
 
@@ -368,37 +348,7 @@ export function createQueryLibraryTool(
             type: "array",
             description:
               "Advanced search clauses, forwarded to Zotero's own search engine. Use this for anything the nine simple filters cannot express — fulltextContent, abstractNote, DOI, publisher, dateAdded, dateModified, note, annotationText, citationKey, retracted, publications, and every other Zotero search condition. Only valid with entity:'items'.",
-            items: {
-              type: "object",
-              additionalProperties: false,
-              required: ["condition", "operator"],
-              properties: {
-                condition: {
-                  type: "string",
-                  description:
-                    "A Zotero search condition, e.g. 'title', 'abstractNote', 'fulltextContent', 'dateAdded', 'DOI', 'itemType', 'tag', 'collection', 'note', 'annotationText', 'citationKey', 'retracted'.",
-                },
-                operator: {
-                  type: "string",
-                  description:
-                    "An operator the condition accepts, e.g. is, isNot, contains, doesNotContain, beginsWith, isBefore, isAfter, isInTheLast, isLessThan, isGreaterThan, true, false. An invalid pairing is rejected with the list of valid operators for that condition.",
-                },
-                value: {
-                  description: "The value to compare against.",
-                  anyOf: [{ type: "string" }, { type: "number" }],
-                },
-                mode: {
-                  type: "string",
-                  description:
-                    "Sub-mode for conditions that take one, notably fulltextContent with 'phrase' or 'regexp'.",
-                },
-                required: {
-                  type: "boolean",
-                  description:
-                    "Force this clause to be required even under joinMode:'any'.",
-                },
-              },
-            },
+            items: SEARCH_CONDITION_SCHEMA,
           },
           joinMode: {
             type: "string",

--- a/src/agent/tools/searchConditions.ts
+++ b/src/agent/tools/searchConditions.ts
@@ -1,0 +1,56 @@
+import type { AgentSearchCondition } from "../services/zoteroGateway";
+import { validateObject } from "./shared";
+
+// Model-facing names must also be valid MFJS property names. Zotero's native
+// `required` flag is represented as `isRequired` in both search tools.
+export const SEARCH_CONDITION_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["condition", "operator"],
+  properties: {
+    condition: {
+      type: "string",
+      description:
+        "A Zotero search condition, e.g. 'title', 'abstractNote', 'fulltextContent', 'dateAdded', 'DOI', 'itemType', 'tag', 'collection', 'note', 'annotationText', 'citationKey', 'retracted'.",
+    },
+    operator: {
+      type: "string",
+      description:
+        "An operator the condition accepts, e.g. is, isNot, contains, doesNotContain, beginsWith, isBefore, isAfter, isInTheLast, isLessThan, isGreaterThan, true, false. An invalid pairing is rejected with the list of valid operators for that condition.",
+    },
+    value: {
+      description: "The value to compare against.",
+      anyOf: [{ type: "string" }, { type: "number" }],
+    },
+    mode: {
+      type: "string",
+      description:
+        "Sub-mode for conditions that take one, notably fulltextContent with 'phrase' or 'regexp'.",
+    },
+    isRequired: {
+      type: "boolean",
+      description:
+        "Force this clause to be required even under joinMode:'any'.",
+    },
+  },
+};
+
+/** Parse tool input without duplicating Zotero's condition/operator vocabulary. */
+export function parseSearchCondition(
+  value: unknown,
+): AgentSearchCondition | undefined {
+  if (!validateObject<Record<string, unknown>>(value)) return undefined;
+  const condition =
+    typeof value.condition === "string" ? value.condition.trim() : "";
+  if (!condition) return undefined;
+  return {
+    condition,
+    operator: typeof value.operator === "string" ? value.operator.trim() : "",
+    value:
+      typeof value.value === "string" || typeof value.value === "number"
+        ? value.value
+        : undefined,
+    mode: typeof value.mode === "string" ? value.mode.trim() : undefined,
+    required: value.isRequired === true ? true : undefined,
+  };
+}

--- a/src/agent/tools/write/savedSearches.ts
+++ b/src/agent/tools/write/savedSearches.ts
@@ -15,6 +15,10 @@ import {
 import type { ZoteroGateway } from "../../services/zoteroGateway";
 import { ok, fail, validateObject, normalizePositiveInt } from "../shared";
 import {
+  SEARCH_CONDITION_SCHEMA,
+  parseSearchCondition,
+} from "../searchConditions";
+import {
   executeAndRecordUndo,
   planLibraryMutations,
 } from "./mutateLibraryShared";
@@ -52,18 +56,7 @@ export function createSavedSearchTool(
             type: "array",
             description:
               "The conditions to save, in the same shape library_search takes.",
-            items: {
-              type: "object",
-              additionalProperties: false,
-              required: ["condition", "operator"],
-              properties: {
-                condition: { type: "string" },
-                operator: { type: "string" },
-                value: { anyOf: [{ type: "string" }, { type: "number" }] },
-                mode: { type: "string" },
-                required: { type: "boolean" },
-              },
-            },
+            items: SEARCH_CONDITION_SCHEMA,
           },
           joinMode: { type: "string", enum: ["all", "any"] },
           savedSearchId: {
@@ -126,22 +119,8 @@ export function createSavedSearchTool(
       }
       const conditions: SaveSavedSearchOperation["conditions"] = [];
       for (const raw of args.conditions) {
-        if (!validateObject<Record<string, unknown>>(raw)) continue;
-        const condition =
-          typeof raw.condition === "string" ? raw.condition.trim() : "";
-        const operator =
-          typeof raw.operator === "string" ? raw.operator.trim() : "";
-        if (!condition || !operator) continue;
-        conditions.push({
-          condition,
-          operator,
-          value:
-            typeof raw.value === "string" || typeof raw.value === "number"
-              ? raw.value
-              : undefined,
-          mode: typeof raw.mode === "string" ? raw.mode.trim() : undefined,
-          required: raw.required === true ? true : undefined,
-        });
+        const condition = parseSearchCondition(raw);
+        if (condition?.operator) conditions.push(condition);
       }
       if (!conditions.length) {
         return fail("Every condition needs a condition name and an operator.");

--- a/test-workflows/libraryOperations.workflow.test.ts
+++ b/test-workflows/libraryOperations.workflow.test.ts
@@ -2,6 +2,8 @@ import { assert } from "chai";
 import { ZoteroGateway } from "../src/agent/services/zoteroGateway";
 import { LibraryMutationService } from "../src/agent/services/libraryMutationService";
 import { replayLibraryInverse } from "../test/helpers/replayLibraryInverse";
+import { createQueryLibraryTool } from "../src/agent/tools/read/queryLibrary";
+import { createSavedSearchTool } from "../src/agent/tools/write/savedSearches";
 
 declare const Zotero: any;
 
@@ -314,6 +316,74 @@ describe("library operations against real Zotero", function () {
   // ── Stage 1: the search vocabulary ────────────────────────────────────────
 
   describe("advanced search conditions", function () {
+    it("preserves isRequired through both search tools and native persistence", async function () {
+      const included = await makeItem(
+        "journalArticle",
+        "RequiredClause SharedClause",
+      );
+      const excluded = await makeItem("journalArticle", "SharedClause");
+      const g = gateway();
+      const conditions = [
+        {
+          condition: "title",
+          operator: "contains",
+          value: "RequiredClause",
+          isRequired: true,
+        },
+        {
+          condition: "title",
+          operator: "contains",
+          value: `SharedClause-${SUFFIX}`,
+        },
+      ];
+      const query = createQueryLibraryTool(g).validate({
+        entity: "items",
+        mode: "search",
+        conditions,
+        joinMode: "any",
+      });
+      assert.isTrue(query.ok);
+      if (!query.ok) return;
+      const result = await g.searchItemsByConditions({
+        libraryID: libraryID(),
+        conditions: query.value.conditions!,
+        joinMode: query.value.joinMode,
+      });
+      assert.include(
+        result.items.map((item) => item.itemId),
+        included.id,
+      );
+      assert.notInclude(
+        result.items.map((item) => item.itemId),
+        excluded.id,
+      );
+
+      const parsed = createSavedSearchTool(g).validate({
+        action: "save",
+        name: `RequiredClause-${SUFFIX}`,
+        conditions,
+        joinMode: "any",
+      });
+      assert.isTrue(parsed.ok);
+      if (!parsed.ok || parsed.value.operation.type !== "save_saved_search")
+        return;
+      const saved = await g.saveSavedSearch({
+        ...parsed.value.operation,
+        libraryID: libraryID(),
+      });
+      created.searches.push(saved.savedSearchId);
+      const required = await Zotero.DB.valueQueryAsync(
+        "SELECT required FROM savedSearchConditions WHERE savedSearchID=? AND condition=? AND value=?",
+        [saved.savedSearchId, "title", "RequiredClause"],
+      );
+      assert.equal(Number(required), 1, "the mandatory clause must persist");
+      const savedIds = (
+        await Zotero.Searches.get(saved.savedSearchId).search()
+      ).map(Number);
+      assert.include(savedIds, included.id);
+      assert.notInclude(savedIds, excluded.id);
+    });
+
     it("returns the same ids as a raw Zotero.Search", async function () {
       const item = await makeItem("journalArticle", "ConditionProbe");
 

--- a/test/librarySearchConditions.test.ts
+++ b/test/librarySearchConditions.test.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import { ZoteroGateway } from "../src/agent/services/zoteroGateway";
 import { createQueryLibraryTool } from "../src/agent/tools/read/queryLibrary";
+import { createSavedSearchTool } from "../src/agent/tools/write/savedSearches";
 
 /**
  * The agent had nine hand-written filters against Zotero's own ~130 search
@@ -276,6 +277,46 @@ describe("library_search advanced conditions", function () {
   describe("tool-level gating", function () {
     function tool() {
       return createQueryLibraryTool(gateway());
+    }
+
+    for (const isRequired of [true, false, undefined]) {
+      it(`preserves isRequired=${String(isRequired)} in both search tools`, function () {
+        const conditions = [
+          {
+            condition: "title",
+            operator: "contains",
+            value: "paper",
+            isRequired,
+          },
+        ];
+        const query = tool().validate({
+          entity: "items",
+          mode: "search",
+          conditions,
+          joinMode: "any",
+        });
+        const saved = createSavedSearchTool(gateway()).validate({
+          action: "save",
+          name: "Required clause",
+          conditions,
+          joinMode: "any",
+        });
+        assert.isTrue(query.ok);
+        assert.isTrue(saved.ok);
+        if (!query.ok || !saved.ok) return;
+        assert.equal(
+          query.value.conditions?.[0].required,
+          isRequired || undefined,
+        );
+        assert.equal(query.value.joinMode, "any");
+        assert.equal(saved.value.operation.type, "save_saved_search");
+        if (saved.value.operation.type !== "save_saved_search") return;
+        assert.equal(
+          saved.value.operation.conditions[0].required,
+          isRequired || undefined,
+        );
+        assert.equal(saved.value.operation.joinMode, "any");
+      });
     }
 
     it("refuses conditions on entities that are not searched that way", function () {

--- a/test/openaiCompatibleAgentAdapter.test.ts
+++ b/test/openaiCompatibleAgentAdapter.test.ts
@@ -151,6 +151,94 @@ describe("OpenAICompatibleAgentAdapter", function () {
     );
   });
 
+  it("moves Kimi anyOf types into the union branches", async function () {
+    let capturedBody: Record<string, unknown> = {};
+    (
+      globalThis as typeof globalThis & {
+        ztoolkit: { getGlobal: (name: string) => unknown };
+      }
+    ).ztoolkit = {
+      getGlobal: (name: string) => {
+        if (name !== "fetch") return undefined;
+        return async (_url: string, init?: RequestInit) => {
+          capturedBody = JSON.parse(String(init?.body || "{}")) as Record<
+            string,
+            unknown
+          >;
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: { get: () => "application/json" },
+            json: async () => ({ choices: [{ message: { content: "OK" } }] }),
+            text: async () => "",
+          };
+        };
+      },
+    };
+
+    const inputSchema = {
+      type: "object",
+      properties: {
+        target: {
+          type: "object",
+          properties: {
+            itemId: { type: "number" },
+            name: { type: "string" },
+          },
+          additionalProperties: false,
+          anyOf: [{ required: ["itemId"] }, { required: ["name"] }],
+        },
+        pages: {
+          anyOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+    };
+
+    await adapter.runStep({
+      request: makeRequest({
+        model: "kimi-for-coding",
+        apiBase: "https://api.kimi.com/coding/v1",
+        providerProtocol: "openai_chat_compat",
+      }),
+      messages: [{ role: "user", content: "Read the selected paper" }],
+      tools: [
+        {
+          name: "paper_read",
+          description: "read paper",
+          inputSchema,
+          mutability: "read",
+          requiresConfirmation: false,
+        },
+      ],
+    });
+
+    const serializedTools = capturedBody.tools as Array<{
+      function: {
+        parameters: {
+          properties: {
+            target: Record<string, unknown>;
+            pages: { anyOf: Array<Record<string, unknown>> };
+          };
+        };
+      };
+    }>;
+    const target = serializedTools[0].function.parameters.properties.target;
+    const targetVariants = target.anyOf as Array<Record<string, unknown>>;
+    assert.notProperty(target, "type");
+    assert.deepEqual(
+      targetVariants.map((variant) => variant.type),
+      ["object", "object"],
+    );
+    assert.deepEqual(
+      serializedTools[0].function.parameters.properties.pages.anyOf.map(
+        (variant) => variant.type,
+      ),
+      ["string", "number"],
+    );
+    assert.equal(inputSchema.properties.target.type, "object");
+  });
+
   it("redacts malformed streamed tool argument JSON", async function () {
     (
       globalThis as typeof globalThis & {

--- a/test/openaiCompatibleAgentAdapter.test.ts
+++ b/test/openaiCompatibleAgentAdapter.test.ts
@@ -21,6 +21,15 @@ const MOONSHOT_ANY_OF_SIBLING_CONSTRAINTS = [
   "default",
 ];
 
+// MoonshotAI/walle model.go: InvalidPropertyNames (server/ultra validation).
+const MOONSHOT_RESERVED_PROPERTY_NAMES = new Set([
+  "$defs",
+  "$ref",
+  "anyOf",
+  "required",
+  "additionalProperties",
+]);
+
 function assertMoonshotSchema(
   schema: unknown,
   path: string,
@@ -56,6 +65,10 @@ function assertMoonshotSchema(
     assert.isObject(row.properties, `${path}.properties must be an object`);
     const properties = row.properties as Record<string, unknown>;
     for (const [key, value] of Object.entries(properties)) {
+      assert.isFalse(
+        MOONSHOT_RESERVED_PROPERTY_NAMES.has(key),
+        `${path}.properties.${key} is a reserved Moonshot property name`,
+      );
       assertMoonshotSchema(value, `${path}.properties.${key}`);
     }
     if (row.required !== undefined) {
@@ -294,6 +307,22 @@ describe("OpenAICompatibleAgentAdapter", function () {
       assertMoonshotSchema(
         tool.function.parameters,
         `tools.${tool.function.name}.parameters`,
+      );
+    }
+
+    for (const name of ["library_search", "saved_search_update"]) {
+      const schema = serializedTools.find(
+        (tool) => tool.function.name === name,
+      )!.function.parameters as unknown as {
+        properties: {
+          conditions: { items: { properties: Record<string, unknown> } };
+        };
+      };
+      assert.deepInclude(
+        schema.properties.conditions.items.properties.isRequired,
+        {
+          type: "boolean",
+        },
       );
     }
 

--- a/test/openaiCompatibleAgentAdapter.test.ts
+++ b/test/openaiCompatibleAgentAdapter.test.ts
@@ -1,8 +1,89 @@
 import { assert } from "chai";
 import { OpenAICompatibleAgentAdapter } from "../src/agent/model/openaiCompatible";
 import type { AgentRuntimeRequest, ToolSpec } from "../src/agent/types";
+import { createBuiltInToolRegistry } from "../src/agent/tools";
 import { isMalformedToolArgumentsDiagnostic } from "../src/agent/toolArgumentDiagnostics";
 import { PAPER_CITATION_CONTRACT } from "../src/shared/instructionContracts";
+
+const MOONSHOT_ANY_OF_SIBLING_CONSTRAINTS = [
+  "type",
+  "properties",
+  "required",
+  "additionalProperties",
+  "items",
+  "enum",
+  "maximum",
+  "minimum",
+  "maxLength",
+  "minLength",
+  "maxItems",
+  "minItems",
+  "default",
+];
+
+function assertMoonshotSchema(
+  schema: unknown,
+  path: string,
+  allowEmpty = false,
+): void {
+  assert.isObject(schema, `${path} must be an object schema`);
+  assert.isNotArray(schema, `${path} must not be an array`);
+  const row = schema as Record<string, unknown>;
+  if (!Object.keys(row).length && allowEmpty) return;
+  for (const key of ["allOf", "not"]) {
+    assert.notProperty(row, key, `${path} uses unsupported keyword ${key}`);
+  }
+
+  if (row.anyOf !== undefined) {
+    assert.isArray(row.anyOf, `${path}.anyOf must be an array`);
+    assert.isNotEmpty(row.anyOf, `${path}.anyOf must not be empty`);
+    for (const key of MOONSHOT_ANY_OF_SIBLING_CONSTRAINTS) {
+      assert.notProperty(
+        row,
+        key,
+        `${path}.${key} must be distributed into the anyOf branches`,
+      );
+    }
+    for (const [index, variant] of row.anyOf.entries()) {
+      assertMoonshotSchema(variant, `${path}.anyOf[${index}]`);
+    }
+  } else if (row.$ref === undefined) {
+    assert.property(row, "type", `${path} must declare a type`);
+  }
+
+  if (row.properties !== undefined) {
+    assert.equal(row.type, "object", `${path}.properties requires object type`);
+    assert.isObject(row.properties, `${path}.properties must be an object`);
+    const properties = row.properties as Record<string, unknown>;
+    for (const [key, value] of Object.entries(properties)) {
+      assertMoonshotSchema(value, `${path}.properties.${key}`);
+    }
+    if (row.required !== undefined) {
+      assert.isArray(row.required, `${path}.required must be an array`);
+      for (const requiredKey of row.required) {
+        assert.isTrue(
+          typeof requiredKey === "string" && requiredKey in properties,
+          `${path}.required contains undeclared property ${String(requiredKey)}`,
+        );
+      }
+    }
+  }
+
+  if (row.items !== undefined) {
+    assert.equal(row.type, "array", `${path}.items requires array type`);
+    assertMoonshotSchema(row.items, `${path}.items`);
+  }
+  if (
+    row.additionalProperties &&
+    typeof row.additionalProperties === "object"
+  ) {
+    assertMoonshotSchema(
+      row.additionalProperties,
+      `${path}.additionalProperties`,
+      true,
+    );
+  }
+}
 
 function makeSseStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
@@ -151,7 +232,7 @@ describe("OpenAICompatibleAgentAdapter", function () {
     );
   });
 
-  it("moves Kimi anyOf types into the union branches", async function () {
+  it("normalizes the built-in Kimi tool registry into complete schemas", async function () {
     let capturedBody: Record<string, unknown> = {};
     (
       globalThis as typeof globalThis & {
@@ -177,23 +258,16 @@ describe("OpenAICompatibleAgentAdapter", function () {
       },
     };
 
-    const inputSchema = {
-      type: "object",
-      properties: {
-        target: {
-          type: "object",
-          properties: {
-            itemId: { type: "number" },
-            name: { type: "string" },
-          },
-          additionalProperties: false,
-          anyOf: [{ required: ["itemId"] }, { required: ["name"] }],
-        },
-        pages: {
-          anyOf: [{ type: "string" }, { type: "number" }],
-        },
-      },
-    };
+    const registry = createBuiltInToolRegistry({
+      zoteroGateway: {} as never,
+      pdfService: {} as never,
+      pdfPageService: {} as never,
+      retrievalService: {} as never,
+    });
+    const registeredTools = registry.listTools();
+    const originalPaperSchema = registeredTools.find(
+      (tool) => tool.name === "paper_read",
+    )!.inputSchema as Record<string, unknown>;
 
     await adapter.runStep({
       request: makeRequest({
@@ -202,19 +276,12 @@ describe("OpenAICompatibleAgentAdapter", function () {
         providerProtocol: "openai_chat_compat",
       }),
       messages: [{ role: "user", content: "Read the selected paper" }],
-      tools: [
-        {
-          name: "paper_read",
-          description: "read paper",
-          inputSchema,
-          mutability: "read",
-          requiresConfirmation: false,
-        },
-      ],
+      tools: registeredTools,
     });
 
     const serializedTools = capturedBody.tools as Array<{
       function: {
+        name: string;
         parameters: {
           properties: {
             target: Record<string, unknown>;
@@ -223,20 +290,42 @@ describe("OpenAICompatibleAgentAdapter", function () {
         };
       };
     }>;
-    const target = serializedTools[0].function.parameters.properties.target;
+    for (const tool of serializedTools) {
+      assertMoonshotSchema(
+        tool.function.parameters,
+        `tools.${tool.function.name}.parameters`,
+      );
+    }
+
+    const paperParameters = serializedTools.find(
+      (tool) => tool.function.name === "paper_read",
+    )!.function.parameters;
+    const target = paperParameters.properties.target;
     const targetVariants = target.anyOf as Array<Record<string, unknown>>;
     assert.notProperty(target, "type");
+    for (const variant of targetVariants) {
+      assert.equal(variant.type, "object");
+      assert.hasAllKeys(variant.properties as Record<string, unknown>, [
+        "contextItemId",
+        "itemId",
+        "paperContext",
+        "attachmentId",
+        "name",
+      ]);
+      assert.equal(variant.additionalProperties, false);
+    }
     assert.deepEqual(
-      targetVariants.map((variant) => variant.type),
-      ["object", "object"],
+      paperParameters.properties.pages.anyOf.map((variant) => variant.type),
+      ["string", "number", "array"],
     );
-    assert.deepEqual(
-      serializedTools[0].function.parameters.properties.pages.anyOf.map(
-        (variant) => variant.type,
-      ),
-      ["string", "number"],
+    assert.equal(
+      (
+        (originalPaperSchema.properties as Record<string, unknown>)
+          .target as Record<string, unknown>
+      ).type,
+      "object",
     );
-    assert.equal(inputSchema.properties.target.type, "object");
+    assert.property(originalPaperSchema, "allOf");
   });
 
   it("redacts malformed streamed tool argument JSON", async function () {


### PR DESCRIPTION
Fixes #416

## Summary

- normalize OpenAI-compatible tool schemas only for detected Kimi/Moonshot endpoints
- move a parent `type` into `anyOf` branches that do not already declare one, matching Kimi's validator
- keep the canonical tool schema immutable so other providers are unaffected
- cover nested unions and preserve explicit branch types with an adapter regression test

## Validation

- full unit suite: 4,232 passing, 1 pending
- `tsc --noEmit`
- full ESLint suite
- Prettier check for changed files
- production plugin build
- workflow test-mode bundle build (the local container has no Zotero Desktop host; GitHub Actions will run the integration harness)

Note: the repository-wide Prettier check currently reports the unchanged upstream `README.md`; this PR does not modify that file.