### PR TITLE
feat(mineru): open and focus manager from item context menu

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -402,6 +402,9 @@ async function onMainWindowLoad(win: _ZoteroTypes.MainWindow): Promise<void> {
     openStandaloneChat: (options) => {
       openStandaloneChat({ initialItem: options?.initialItem || null });
     },
+    openMineruManager: () => {
+      Zotero.Utilities.Internal.openPreferences(PREFERENCES_PANE_ID);
+    },
   });
 
   // Keyboard shortcut: Ctrl/Cmd+Shift+L

--- a/src/modules/contextPanel/zoteroItemContextMenu.ts
+++ b/src/modules/contextPanel/zoteroItemContextMenu.ts
@@ -1,4 +1,8 @@
 import { t } from "../../utils/i18n";
+import {
+  collectMineruPdfAttachmentIds,
+  requestMineruManagerSelection,
+} from "../mineruManagerNavigation";
 import type { ContextSelectionActionResult } from "./contextSelectionActions";
 import type { ZoteroToolkit } from "zotero-plugin-toolkit";
 
@@ -31,6 +35,7 @@ type RegisterMenuDeps = {
   ztoolkit: Pick<ZoteroToolkit, "Menu">;
   getSelectedItems: () => Zotero.Item[];
   openStandaloneChat: OpenStandaloneChat;
+  openMineruManager?: () => void;
 };
 
 type DispatchDeps = {
@@ -38,6 +43,7 @@ type DispatchDeps = {
 };
 
 const MENU_ID = "llmforzotero-add-items-as-context";
+const MINERU_MENU_ID = "llmforzotero-recognize-pdfs-with-mineru";
 const MENU_SEPARATOR_BEFORE_ID = "llmforzotero-add-items-as-context-before";
 const MENU_SEPARATOR_AFTER_ID = "llmforzotero-add-items-as-context-after";
 const activeContextSurfaceTargets = new Map<
@@ -120,6 +126,20 @@ export function registerZoteroItemContextMenu(deps: RegisterMenuDeps): void {
       });
     },
   });
+  if (deps.openMineruManager) {
+    deps.ztoolkit.Menu?.register?.("item", {
+      tag: "menuitem",
+      id: MINERU_MENU_ID,
+      label: t("Recognize PDFs with MinerU"),
+      commandListener: () => {
+        const attachmentIds = collectMineruPdfAttachmentIds(
+          deps.getSelectedItems(),
+        );
+        if (!requestMineruManagerSelection(attachmentIds)) return;
+        deps.openMineruManager?.();
+      },
+    });
+  }
   deps.ztoolkit.Menu?.register?.("item", {
     tag: "menuseparator",
     id: MENU_SEPARATOR_AFTER_ID,

--- a/src/modules/contextPanel/zoteroItemContextMenu.ts
+++ b/src/modules/contextPanel/zoteroItemContextMenu.ts
@@ -1,6 +1,7 @@
 import { t } from "../../utils/i18n";
 import {
   collectMineruPdfAttachmentIds,
+  requestMineruManagerOpen,
   requestMineruManagerSelection,
 } from "../mineruManagerNavigation";
 import type { ContextSelectionActionResult } from "./contextSelectionActions";
@@ -130,12 +131,15 @@ export function registerZoteroItemContextMenu(deps: RegisterMenuDeps): void {
     deps.ztoolkit.Menu?.register?.("item", {
       tag: "menuitem",
       id: MINERU_MENU_ID,
-      label: t("Recognize PDFs with MinerU"),
+      label: t("Open MinerU Manager"),
       commandListener: () => {
         const attachmentIds = collectMineruPdfAttachmentIds(
           deps.getSelectedItems(),
         );
-        if (!requestMineruManagerSelection(attachmentIds)) return;
+        requestMineruManagerOpen();
+        if (attachmentIds.length) {
+          requestMineruManagerSelection(attachmentIds);
+        }
         deps.openMineruManager?.();
       },
     });

--- a/src/modules/mineruManagerNavigation.ts
+++ b/src/modules/mineruManagerNavigation.ts
@@ -1,0 +1,103 @@
+type MineruManagerSelectionTarget = (
+  attachmentIds: readonly number[],
+) => boolean | void;
+
+type ZoteroItemResolver = (
+  attachmentId: number,
+) => Zotero.Item | null | undefined;
+
+const selectionTargets = new Set<MineruManagerSelectionTarget>();
+let pendingAttachmentIds: number[] | null = null;
+
+function normalizeAttachmentIds(attachmentIds: readonly number[]): number[] {
+  return [
+    ...new Set(
+      attachmentIds.filter(
+        (attachmentId) => Number.isInteger(attachmentId) && attachmentId > 0,
+      ),
+    ),
+  ];
+}
+
+function isPdfAttachment(item: Zotero.Item | null | undefined): boolean {
+  return Boolean(
+    item?.isAttachment?.() && item.attachmentContentType === "application/pdf",
+  );
+}
+
+export function collectMineruPdfAttachmentIds(
+  items: readonly Zotero.Item[],
+  resolveItem: ZoteroItemResolver = (attachmentId) =>
+    Zotero.Items.get(attachmentId),
+): number[] {
+  const attachmentIds: number[] = [];
+
+  for (const item of items) {
+    if (!item) continue;
+    if (isPdfAttachment(item)) {
+      attachmentIds.push(item.id);
+      continue;
+    }
+    if (!item.isRegularItem?.()) continue;
+
+    let childIds: number[] = [];
+    try {
+      childIds = item.getAttachments();
+    } catch {
+      continue;
+    }
+    for (const childId of childIds) {
+      const child = resolveItem(childId);
+      if (isPdfAttachment(child)) attachmentIds.push(childId);
+    }
+  }
+
+  return normalizeAttachmentIds(attachmentIds);
+}
+
+export function requestMineruManagerSelection(
+  attachmentIds: readonly number[],
+): boolean {
+  const normalized = normalizeAttachmentIds(attachmentIds);
+  if (!normalized.length) return false;
+
+  pendingAttachmentIds = normalized;
+  let handled = false;
+  for (const target of selectionTargets) {
+    try {
+      handled = target(normalized) !== false || handled;
+    } catch {
+      /* keep the request pending for another/next manager target */
+    }
+  }
+  if (handled) pendingAttachmentIds = null;
+  return true;
+}
+
+export function registerMineruManagerSelectionTarget(
+  target: MineruManagerSelectionTarget,
+): () => void {
+  selectionTargets.add(target);
+  if (pendingAttachmentIds) {
+    try {
+      if (target(pendingAttachmentIds) !== false) {
+        pendingAttachmentIds = null;
+      }
+    } catch {
+      /* leave the request pending so a later target can apply it */
+    }
+  }
+
+  return () => {
+    selectionTargets.delete(target);
+  };
+}
+
+export function hasPendingMineruManagerSelection(): boolean {
+  return Boolean(pendingAttachmentIds?.length);
+}
+
+export function clearMineruManagerNavigationForTests(): void {
+  selectionTargets.clear();
+  pendingAttachmentIds = null;
+}

--- a/src/modules/mineruManagerNavigation.ts
+++ b/src/modules/mineruManagerNavigation.ts
@@ -1,13 +1,16 @@
 type MineruManagerSelectionTarget = (
   attachmentIds: readonly number[],
 ) => boolean | void;
+type MineruManagerOpenTarget = () => boolean | void;
 
 type ZoteroItemResolver = (
   attachmentId: number,
 ) => Zotero.Item | null | undefined;
 
 const selectionTargets = new Set<MineruManagerSelectionTarget>();
+const openTargets = new Set<MineruManagerOpenTarget>();
 let pendingAttachmentIds: number[] | null = null;
+let pendingOpenRequest = false;
 
 function normalizeAttachmentIds(attachmentIds: readonly number[]): number[] {
   return [
@@ -29,11 +32,13 @@ export function collectMineruPdfAttachmentIds(
   items: readonly Zotero.Item[],
   resolveItem: ZoteroItemResolver = (attachmentId) =>
     Zotero.Items.get(attachmentId),
+  supportedLibraryId: number = Zotero.Libraries.userLibraryID,
 ): number[] {
   const attachmentIds: number[] = [];
 
   for (const item of items) {
     if (!item) continue;
+    if (item.libraryID !== supportedLibraryId) continue;
     if (isPdfAttachment(item)) {
       attachmentIds.push(item.id);
       continue;
@@ -46,13 +51,54 @@ export function collectMineruPdfAttachmentIds(
     } catch {
       continue;
     }
-    for (const childId of childIds) {
-      const child = resolveItem(childId);
-      if (isPdfAttachment(child)) attachmentIds.push(childId);
+    for (const childId of Array.isArray(childIds) ? childIds : []) {
+      let child: Zotero.Item | null | undefined;
+      try {
+        child = resolveItem(childId);
+      } catch {
+        continue;
+      }
+      if (child?.libraryID === supportedLibraryId && isPdfAttachment(child)) {
+        attachmentIds.push(childId);
+      }
     }
   }
 
   return normalizeAttachmentIds(attachmentIds);
+}
+
+export function requestMineruManagerOpen(): void {
+  pendingOpenRequest = true;
+  let handled = false;
+  for (const target of openTargets) {
+    try {
+      handled = target() !== false || handled;
+    } catch {
+      /* keep the request pending for another/next preferences target */
+    }
+  }
+  if (handled) pendingOpenRequest = false;
+}
+
+export function registerMineruManagerOpenTarget(
+  target: MineruManagerOpenTarget,
+): () => void {
+  openTargets.add(target);
+  if (pendingOpenRequest) {
+    try {
+      if (target() !== false) pendingOpenRequest = false;
+    } catch {
+      /* leave the request pending so a later target can apply it */
+    }
+  }
+
+  return () => {
+    openTargets.delete(target);
+  };
+}
+
+export function hasPendingMineruManagerOpenRequest(): boolean {
+  return pendingOpenRequest;
 }
 
 export function requestMineruManagerSelection(
@@ -99,5 +145,7 @@ export function hasPendingMineruManagerSelection(): boolean {
 
 export function clearMineruManagerNavigationForTests(): void {
   selectionTargets.clear();
+  openTargets.clear();
   pendingAttachmentIds = null;
+  pendingOpenRequest = false;
 }

--- a/src/modules/mineruManagerScript.ts
+++ b/src/modules/mineruManagerScript.ts
@@ -20,7 +20,7 @@ import type {
 } from "./mineruBatchProcessor";
 import { getMineruItemDir } from "./contextPanel/mineruCache";
 import {
-  getMineruStatus,
+  getItemStatus,
   onProcessingStatusChange,
   type MineruStatus,
 } from "./mineruProcessingStatus";
@@ -148,6 +148,37 @@ export function shouldShowMineruManagerItem(
   _item: MineruManagerVisibilityInput,
 ): boolean {
   return true;
+}
+
+export function resolveMineruManagerDisplayStatus(
+  availability: MineruItemEntry["availability"],
+  runtimeStatus: MineruStatus | undefined,
+): MineruStatus {
+  if (runtimeStatus === "processing") return "processing";
+  if (availability !== "missing") return "cached";
+  if (runtimeStatus === "failed") return "failed";
+  if (runtimeStatus === "cached") return "cached";
+  return "idle";
+}
+
+export type MineruCenteredScrollInput = {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+  containerTop: number;
+  targetTop: number;
+  targetHeight: number;
+};
+
+export function calculateMineruCenteredScrollTop(
+  input: MineruCenteredScrollInput,
+): number {
+  const targetTopInContent =
+    input.targetTop - input.containerTop + input.scrollTop;
+  const desiredTop =
+    targetTopInContent - (input.clientHeight - input.targetHeight) / 2;
+  const maxScrollTop = Math.max(0, input.scrollHeight - input.clientHeight);
+  return Math.min(maxScrollTop, Math.max(0, desiredTop));
 }
 
 export type MineruManagerSearchInput = Pick<
@@ -324,6 +355,7 @@ export async function registerMineruManagerScript(
   let itemSearchQuery = "";
   let itemSearchInput: HTMLInputElement | null = null;
   let itemSearchCount: HTMLSpanElement | null = null;
+  let navigationHighlightTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Sorting
   let sortKey: SortKey = "dateAdded";
@@ -365,11 +397,76 @@ export async function registerMineruManagerScript(
     return allItems.filter(shouldShowMineruManagerItem);
   }
 
-  function applyExternalAttachmentSelection(
-    attachmentIds: readonly number[],
+  function runAfterMineruLayout(callback: () => void): void {
+    if (typeof win.requestAnimationFrame !== "function") {
+      win.setTimeout(callback, 0);
+      return;
+    }
+    win.requestAnimationFrame(() => {
+      win.requestAnimationFrame(callback);
+    });
+  }
+
+  function focusExternalSelection(
+    attachmentId: number | undefined,
+    parentItemId: number | undefined,
   ): void {
+    if (!itemsList) return;
+    const selectedRow =
+      attachmentId === undefined
+        ? null
+        : (doc.querySelector(
+            `[data-attachment-id="${attachmentId}"]`,
+          ) as HTMLElement | null);
+    const parentRow =
+      parentItemId === undefined
+        ? null
+        : (doc.querySelector(
+            `[data-parent-id="${parentItemId}"]`,
+          ) as HTMLElement | null);
+    const targetRow = selectedRow || parentRow;
+    if (!targetRow) return;
+
+    const containerRect = itemsList.getBoundingClientRect();
+    const targetRect = targetRow.getBoundingClientRect();
+    itemsList.scrollTop = calculateMineruCenteredScrollTop({
+      scrollTop: itemsList.scrollTop,
+      clientHeight: itemsList.clientHeight,
+      scrollHeight: itemsList.scrollHeight,
+      containerTop: containerRect.top,
+      targetTop: targetRect.top,
+      targetHeight: targetRect.height,
+    });
+
+    if (navigationHighlightTimer) clearTimeout(navigationHighlightTimer);
+    const previousBoxShadow = targetRow.style.boxShadow;
+    const previousTransition = targetRow.style.transition;
+    targetRow.style.transition = "box-shadow 120ms ease-out";
+    targetRow.style.boxShadow = "inset 0 0 0 2px var(--color-accent, #2563eb)";
+    navigationHighlightTimer = setTimeout(() => {
+      navigationHighlightTimer = null;
+      if (!targetRow.isConnected) return;
+      targetRow.style.boxShadow = previousBoxShadow;
+      targetRow.style.transition = previousTransition;
+    }, 1400);
+  }
+
+  type PreparedExternalSelection = {
+    firstSelectedId: number | undefined;
+    firstParentItemId: number | undefined;
+    filtersChanged: boolean;
+  };
+
+  function prepareExternalAttachmentSelection(
+    attachmentIds: readonly number[],
+  ): PreparedExternalSelection {
     const requestedIds = new Set(attachmentIds);
     const availableItems = getManagerVisibleSourceItems();
+    const filtersChanged =
+      activeCollectionId !== "all" ||
+      tagScope !== "all" ||
+      selectedTags.size > 0 ||
+      itemSearchQuery.trim().length > 0;
 
     // A direct item-tree action should always reveal the requested PDFs, even
     // if the manager was previously narrowed to another folder/tag/search.
@@ -395,32 +492,44 @@ export async function registerMineruManagerScript(
       }
     }
 
-    renderSidebar();
-    renderItemsList();
-
-    const mineruTab = doc.querySelector(
-      '[data-pref-tab="mineru"]',
-    ) as HTMLElement | null;
-    mineruTab?.click();
-
     const firstSelectedId = selectedIds.values().next().value;
     const firstEntry =
       firstSelectedId === undefined
         ? undefined
         : availableItems.find((item) => item.attachmentId === firstSelectedId);
-    const selectedRow =
-      firstSelectedId === undefined
-        ? null
-        : (doc.querySelector(
-            `[data-attachment-id="${firstSelectedId}"]`,
-          ) as HTMLElement | null);
-    const parentRow = firstEntry
-      ? (doc.querySelector(
-          `[data-parent-id="${firstEntry.parentItemId}"]`,
-        ) as HTMLElement | null)
-      : null;
-    selectedRow?.scrollIntoView?.({ block: "nearest" });
-    if (!selectedRow) parentRow?.scrollIntoView?.({ block: "nearest" });
+    return {
+      firstSelectedId,
+      firstParentItemId: firstEntry?.parentItemId,
+      filtersChanged,
+    };
+  }
+
+  function focusPreparedExternalSelection(
+    selection: PreparedExternalSelection,
+  ): void {
+    const mineruTab = doc.querySelector(
+      '[data-pref-tab="mineru"]',
+    ) as HTMLElement | null;
+    mineruTab?.click();
+
+    // Gecko can report stale layout while the preferences tab and list are
+    // switching/rendering. Wait for two paints, then scroll the MinerU list
+    // itself rather than relying on scrollIntoView choosing the right ancestor.
+    runAfterMineruLayout(() => {
+      focusExternalSelection(
+        selection.firstSelectedId,
+        selection.firstParentItemId,
+      );
+    });
+  }
+
+  function applyExternalAttachmentSelection(
+    attachmentIds: readonly number[],
+  ): void {
+    const selection = prepareExternalAttachmentSelection(attachmentIds);
+    if (selection.filtersChanged) renderSidebar();
+    renderItemsList();
+    focusPreparedExternalSelection(selection);
   }
 
   function pruneSelectedIdsToVisibleItems(): void {
@@ -436,7 +545,10 @@ export async function registerMineruManagerScript(
   }
 
   function getAvailabilityDisplayStatus(item: MineruItemEntry): MineruStatus {
-    return isMineruAvailable(item) ? "cached" : "idle";
+    return resolveMineruManagerDisplayStatus(
+      item.availability,
+      getItemStatus(item.attachmentId)?.status,
+    );
   }
 
   function setDotDisplayStatus(
@@ -476,10 +588,10 @@ export async function registerMineruManagerScript(
     entry.cached = availability.status !== "missing";
     const dot = dotElements.get(attachmentId);
     if (dot) {
-      setDotDisplayStatus(dot, await getMineruStatus(attachmentId));
+      setDotDisplayStatus(dot, getAvailabilityDisplayStatus(entry));
       dot.title = getAvailabilityTooltip(entry);
     }
-    void updateParentDotForAttachment(attachmentId);
+    updateParentDotForAttachment(attachmentId);
   }
 
   function resolveTagColor(name: string): string | null {
@@ -1772,28 +1884,10 @@ export async function registerMineruManagerScript(
     );
   }
 
-  async function getResolvedParentDisplayStatus(
-    group: MineruParentGroup,
-  ): Promise<MineruStatus> {
-    const childStatuses = await Promise.all(
-      group.children.map(async (child) => ({
-        availability: child.availability,
-        excluded: child.excluded,
-        status: await getMineruStatus(child.attachmentId),
-      })),
-    );
-    return getMineruParentDisplayStatus(childStatuses);
-  }
-
-  async function updateParentDot(
-    parentId: number,
-    group: MineruParentGroup,
-  ): Promise<void> {
+  function updateParentDot(parentId: number, group: MineruParentGroup): void {
     const parentDot = parentDotElements.get(parentId);
     if (!parentDot) return;
-    const status = await getResolvedParentDisplayStatus(group);
-    if (parentDotElements.get(parentId) !== parentDot) return;
-    setDotDisplayStatus(parentDot, status);
+    setDotDisplayStatus(parentDot, getInitialParentDisplayStatus(group));
   }
 
   function findRenderedGroupForAttachment(
@@ -1815,20 +1909,13 @@ export async function registerMineruManagerScript(
 
   function updateParentDotForAttachment(attachmentId: number): void {
     const group = findRenderedGroupForAttachment(attachmentId);
-    if (group) void updateParentDot(group.parentItemId, group);
+    if (group) updateParentDot(group.parentItemId, group);
   }
 
   function refreshRenderedParentDots(): void {
     for (const group of getVisibleGroups()) {
-      void updateParentDot(group.parentItemId, group);
+      updateParentDot(group.parentItemId, group);
     }
-  }
-
-  async function refreshAttachmentDot(
-    attachmentId: number,
-    dot: HTMLSpanElement,
-  ): Promise<void> {
-    setDotDisplayStatus(dot, await getMineruStatus(attachmentId));
   }
 
   function getSkippedLabel(item: MineruItemEntry): string {
@@ -1879,10 +1966,6 @@ export async function registerMineruManagerScript(
     dot.title = getAvailabilityTooltip(item);
     dotElements.set(item.attachmentId, dot);
     row.appendChild(dot);
-
-    void (async () => {
-      await refreshAttachmentDot(item.attachmentId, dot);
-    })();
 
     const titleSpan = doc.createElement("span");
     titleSpan.style.cssText =
@@ -2055,7 +2138,6 @@ export async function registerMineruManagerScript(
       });
       setDotDisplayStatus(parentDot, getInitialParentDisplayStatus(group));
       parentDotElements.set(group.parentItemId, parentDot);
-      void updateParentDot(group.parentItemId, group);
       parentRow.appendChild(parentDot);
       parentRow.appendChild(chev);
 
@@ -2162,14 +2244,6 @@ export async function registerMineruManagerScript(
           if (selectedIds.has(child.attachmentId))
             childRow.style.background =
               "color-mix(in srgb, var(--color-accent, #2563eb) 12%, transparent)";
-
-          const childDot = dotElements.get(child.attachmentId);
-          if (childDot) {
-            void (async () => {
-              await refreshAttachmentDot(child.attachmentId, childDot);
-              void updateParentDot(group.parentItemId, group);
-            })();
-          }
 
           if (hasSelection) {
             const isSelected = selectedIds.has(child.attachmentId);
@@ -2805,16 +2879,19 @@ export async function registerMineruManagerScript(
   });
 
   const unsubscribeProcessingStatus = onProcessingStatusChange(() => {
-    void (async () => {
-      for (const [attachmentId, dot] of dotElements.entries()) {
-        await refreshAttachmentDot(attachmentId, dot);
-      }
-      refreshRenderedParentDots();
-    })();
+    for (const [attachmentId, dot] of dotElements.entries()) {
+      const entry = allItems.find((item) => item.attachmentId === attachmentId);
+      if (entry) setDotDisplayStatus(dot, getAvailabilityDisplayStatus(entry));
+    }
+    refreshRenderedParentDots();
   });
 
   win.addEventListener("unload", () => {
     stopActiveResize?.();
+    if (navigationHighlightTimer) {
+      clearTimeout(navigationHighlightTimer);
+      navigationHighlightTimer = null;
+    }
     unsubscribe();
     unsubscribeAutoWatch();
     unsubscribeProcessingStatus();
@@ -2833,20 +2910,14 @@ export async function registerMineruManagerScript(
     }
   });
 
-  await loadData();
-  // Default: collapse single-PDF items, expand multi-PDF items
-  const initGroups = groupByParent(allItems);
-  for (const g of initGroups) {
-    if (g.children.length === 1) collapsedParents.add(g.parentItemId);
-  }
-  renderSidebar();
-  renderColumnHeaders();
-  renderItemSearchBar();
-  renderItemsList();
-  syncUIFromState(getMineruBatchState());
-
+  let managerReady = false;
+  let pendingInitialExternalAttachmentIds: number[] | null = null;
   const unregisterManagerSelectionTarget = registerMineruManagerSelectionTarget(
     (attachmentIds) => {
+      if (!managerReady) {
+        pendingInitialExternalAttachmentIds = [...attachmentIds];
+        return true;
+      }
       applyExternalAttachmentSelection(attachmentIds);
       return true;
     },
@@ -2854,4 +2925,24 @@ export async function registerMineruManagerScript(
   win.addEventListener("unload", unregisterManagerSelectionTarget, {
     once: true,
   });
+
+  await loadData();
+  // Default: collapse single-PDF items, expand multi-PDF items
+  const initGroups = groupByParent(allItems);
+  for (const g of initGroups) {
+    if (g.children.length === 1) collapsedParents.add(g.parentItemId);
+  }
+  const initialExternalSelection = pendingInitialExternalAttachmentIds
+    ? prepareExternalAttachmentSelection(pendingInitialExternalAttachmentIds)
+    : null;
+  pendingInitialExternalAttachmentIds = null;
+  renderSidebar();
+  renderColumnHeaders();
+  renderItemSearchBar();
+  renderItemsList();
+  syncUIFromState(getMineruBatchState());
+  managerReady = true;
+  if (initialExternalSelection) {
+    focusPreparedExternalSelection(initialExternalSelection);
+  }
 }

--- a/src/modules/mineruManagerScript.ts
+++ b/src/modules/mineruManagerScript.ts
@@ -53,6 +53,7 @@ import {
   buildMineruFilenameMatcher,
   type MineruFilenameMatcher,
 } from "../utils/mineruConfig";
+import { registerMineruManagerSelectionTarget } from "./mineruManagerNavigation";
 
 /** Show a confirm dialog with a custom title using ztoolkit.Dialog. */
 async function confirmDialog(message: string): Promise<boolean> {
@@ -362,6 +363,64 @@ export async function registerMineruManagerScript(
 
   function getManagerVisibleSourceItems(): MineruItemEntry[] {
     return allItems.filter(shouldShowMineruManagerItem);
+  }
+
+  function applyExternalAttachmentSelection(
+    attachmentIds: readonly number[],
+  ): void {
+    const requestedIds = new Set(attachmentIds);
+    const availableItems = getManagerVisibleSourceItems();
+
+    // A direct item-tree action should always reveal the requested PDFs, even
+    // if the manager was previously narrowed to another folder/tag/search.
+    activeCollectionId = "all";
+    tagScope = "all";
+    selectedTags.clear();
+    itemSearchQuery = "";
+    if (itemSearchInput) itemSearchInput.value = "";
+
+    selectedIds.clear();
+    for (const item of availableItems) {
+      if (requestedIds.has(item.attachmentId)) {
+        selectedIds.add(item.attachmentId);
+      }
+    }
+    lastClickedId = selectedIds.values().next().value ?? null;
+
+    // Make every selected PDF row visible, including single-PDF parent groups
+    // that are collapsed by default.
+    for (const group of groupByParent(availableItems)) {
+      if (group.children.some((child) => selectedIds.has(child.attachmentId))) {
+        collapsedParents.delete(group.parentItemId);
+      }
+    }
+
+    renderSidebar();
+    renderItemsList();
+
+    const mineruTab = doc.querySelector(
+      '[data-pref-tab="mineru"]',
+    ) as HTMLElement | null;
+    mineruTab?.click();
+
+    const firstSelectedId = selectedIds.values().next().value;
+    const firstEntry =
+      firstSelectedId === undefined
+        ? undefined
+        : availableItems.find((item) => item.attachmentId === firstSelectedId);
+    const selectedRow =
+      firstSelectedId === undefined
+        ? null
+        : (doc.querySelector(
+            `[data-attachment-id="${firstSelectedId}"]`,
+          ) as HTMLElement | null);
+    const parentRow = firstEntry
+      ? (doc.querySelector(
+          `[data-parent-id="${firstEntry.parentItemId}"]`,
+        ) as HTMLElement | null)
+      : null;
+    selectedRow?.scrollIntoView?.({ block: "nearest" });
+    if (!selectedRow) parentRow?.scrollIntoView?.({ block: "nearest" });
   }
 
   function pruneSelectedIdsToVisibleItems(): void {
@@ -2785,4 +2844,14 @@ export async function registerMineruManagerScript(
   renderItemSearchBar();
   renderItemsList();
   syncUIFromState(getMineruBatchState());
+
+  const unregisterManagerSelectionTarget = registerMineruManagerSelectionTarget(
+    (attachmentIds) => {
+      applyExternalAttachmentSelection(attachmentIds);
+      return true;
+    },
+  );
+  win.addEventListener("unload", unregisterManagerSelectionTarget, {
+    once: true,
+  });
 }

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -191,7 +191,11 @@ import {
   MINERU_PARSE_FILTERS_CHANGED_EVENT,
   registerMineruManagerScript,
 } from "./mineruManagerScript";
-import { hasPendingMineruManagerSelection } from "./mineruManagerNavigation";
+import {
+  hasPendingMineruManagerOpenRequest,
+  hasPendingMineruManagerSelection,
+  registerMineruManagerOpenTarget,
+} from "./mineruManagerNavigation";
 import {
   cleanSyncedMineruPackages,
   repairMineruSyncPackages,
@@ -1029,8 +1033,19 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
       });
     }
     // A Zotero item-tree MinerU action can open preferences with a pending
-    // attachment selection. Show MinerU immediately instead of flashing Models.
-    switchTab(hasPendingMineruManagerSelection() ? "mineru" : "models");
+    // navigation/attachment request. Show MinerU immediately instead of flashing Models.
+    switchTab(
+      hasPendingMineruManagerOpenRequest() || hasPendingMineruManagerSelection()
+        ? "mineru"
+        : "models",
+    );
+    const unregisterMineruOpenTarget = registerMineruManagerOpenTarget(() => {
+      switchTab("mineru");
+      return true;
+    });
+    _window?.addEventListener("unload", unregisterMineruOpenTarget, {
+      once: true,
+    });
   }
 
   const modelSections = doc.querySelector(

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -191,6 +191,7 @@ import {
   MINERU_PARSE_FILTERS_CHANGED_EVENT,
   registerMineruManagerScript,
 } from "./mineruManagerScript";
+import { hasPendingMineruManagerSelection } from "./mineruManagerNavigation";
 import {
   cleanSyncedMineruPackages,
   repairMineruSyncPackages,
@@ -1027,8 +1028,9 @@ export async function registerPrefsScripts(_window: Window | undefined | null) {
         switchTab(btn.getAttribute("data-pref-tab") || "models");
       });
     }
-    // Activate first tab
-    switchTab("models");
+    // A Zotero item-tree MinerU action can open preferences with a pending
+    // attachment selection. Show MinerU immediately instead of flashing Models.
+    switchTab(hasPendingMineruManagerSelection() ? "mineru" : "models");
   }
 
   const modelSections = doc.querySelector(

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -39,7 +39,7 @@ const zhCN: Record<string, string> = {
   "No context to clear": "没有可清除的上下文",
   "Add Items as Context to LLM-for-Zotero":
     "将条目作为上下文添加到 LLM-for-Zotero",
-  "Recognize PDFs with MinerU": "MinerU 识别",
+  "Open MinerU Manager": "打开 MinerU 管理器",
   "No supported default attachment found": "未找到支持的默认附件",
   Rename: "重命名",
   "Rename chat": "重命名对话",

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -39,6 +39,7 @@ const zhCN: Record<string, string> = {
   "No context to clear": "没有可清除的上下文",
   "Add Items as Context to LLM-for-Zotero":
     "将条目作为上下文添加到 LLM-for-Zotero",
+  "Recognize PDFs with MinerU": "MinerU 识别",
   "No supported default attachment found": "未找到支持的默认附件",
   Rename: "重命名",
   "Rename chat": "重命名对话",

--- a/test/mineruManagerNavigation.test.ts
+++ b/test/mineruManagerNavigation.test.ts
@@ -1,0 +1,81 @@
+import { assert } from "chai";
+import {
+  clearMineruManagerNavigationForTests,
+  collectMineruPdfAttachmentIds,
+  hasPendingMineruManagerSelection,
+  registerMineruManagerSelectionTarget,
+  requestMineruManagerSelection,
+} from "../src/modules/mineruManagerNavigation";
+
+function attachment(id: number, contentType: string): Zotero.Item {
+  return {
+    id,
+    isRegularItem: () => false,
+    isAttachment: () => true,
+    attachmentContentType: contentType,
+  } as unknown as Zotero.Item;
+}
+
+function regularItem(id: number, attachmentIds: number[]): Zotero.Item {
+  return {
+    id,
+    isRegularItem: () => true,
+    isAttachment: () => false,
+    getAttachments: () => attachmentIds,
+  } as unknown as Zotero.Item;
+}
+
+describe("mineruManagerNavigation", function () {
+  afterEach(function () {
+    clearMineruManagerNavigationForTests();
+  });
+
+  it("collects PDF children and direct PDF selections without duplicates", function () {
+    const pdfA = attachment(11, "application/pdf");
+    const pdfB = attachment(12, "application/pdf");
+    const html = attachment(13, "text/html");
+    const itemById = new Map<number, Zotero.Item>([
+      [11, pdfA],
+      [12, pdfB],
+      [13, html],
+    ]);
+
+    assert.deepEqual(
+      collectMineruPdfAttachmentIds(
+        [regularItem(1, [11, 12, 13]), pdfA],
+        (id) => itemById.get(id),
+      ),
+      [11, 12],
+    );
+  });
+
+  it("keeps a selection pending until a MinerU manager target is ready", function () {
+    assert.isTrue(requestMineruManagerSelection([22, 21, 22]));
+    assert.isTrue(hasPendingMineruManagerSelection());
+
+    let received: readonly number[] = [];
+    registerMineruManagerSelectionTarget((attachmentIds) => {
+      received = [...attachmentIds];
+      return true;
+    });
+
+    assert.deepEqual(received, [22, 21]);
+    assert.isFalse(hasPendingMineruManagerSelection());
+  });
+
+  it("delivers a later selection immediately to an active manager", function () {
+    const received: number[][] = [];
+    const unregister = registerMineruManagerSelectionTarget((attachmentIds) => {
+      received.push([...attachmentIds]);
+      return true;
+    });
+
+    assert.isTrue(requestMineruManagerSelection([31, 32]));
+    assert.deepEqual(received, [[31, 32]]);
+    assert.isFalse(hasPendingMineruManagerSelection());
+
+    unregister();
+    assert.isTrue(requestMineruManagerSelection([33]));
+    assert.isTrue(hasPendingMineruManagerSelection());
+  });
+});

--- a/test/mineruManagerNavigation.test.ts
+++ b/test/mineruManagerNavigation.test.ts
@@ -2,23 +2,36 @@ import { assert } from "chai";
 import {
   clearMineruManagerNavigationForTests,
   collectMineruPdfAttachmentIds,
+  hasPendingMineruManagerOpenRequest,
   hasPendingMineruManagerSelection,
+  registerMineruManagerOpenTarget,
   registerMineruManagerSelectionTarget,
+  requestMineruManagerOpen,
   requestMineruManagerSelection,
 } from "../src/modules/mineruManagerNavigation";
 
-function attachment(id: number, contentType: string): Zotero.Item {
+function attachment(
+  id: number,
+  contentType: string,
+  libraryID = 1,
+): Zotero.Item {
   return {
     id,
+    libraryID,
     isRegularItem: () => false,
     isAttachment: () => true,
     attachmentContentType: contentType,
   } as unknown as Zotero.Item;
 }
 
-function regularItem(id: number, attachmentIds: number[]): Zotero.Item {
+function regularItem(
+  id: number,
+  attachmentIds: number[],
+  libraryID = 1,
+): Zotero.Item {
   return {
     id,
+    libraryID,
     isRegularItem: () => true,
     isAttachment: () => false,
     getAttachments: () => attachmentIds,
@@ -44,9 +57,67 @@ describe("mineruManagerNavigation", function () {
       collectMineruPdfAttachmentIds(
         [regularItem(1, [11, 12, 13]), pdfA],
         (id) => itemById.get(id),
+        1,
       ),
       [11, 12],
     );
+  });
+
+  it("collects PDFs across multiple parents while skipping missing children", function () {
+    const firstPdf = attachment(21, "application/pdf");
+    const secondPdf = attachment(22, "application/pdf");
+    const itemById = new Map<number, Zotero.Item>([
+      [21, firstPdf],
+      [22, secondPdf],
+    ]);
+
+    assert.deepEqual(
+      collectMineruPdfAttachmentIds(
+        [regularItem(1, [21, 99]), regularItem(2, [22, 100])],
+        (id) => {
+          if (id === 100) throw new Error("stale Zotero item");
+          return itemById.get(id);
+        },
+        1,
+      ),
+      [21, 22],
+    );
+  });
+
+  it("ignores PDFs from libraries the MinerU manager cannot display", function () {
+    const userPdf = attachment(31, "application/pdf", 1);
+    const groupPdf = attachment(32, "application/pdf", 2);
+    const itemById = new Map<number, Zotero.Item>([
+      [31, userPdf],
+      [32, groupPdf],
+    ]);
+
+    assert.deepEqual(
+      collectMineruPdfAttachmentIds(
+        [regularItem(1, [31], 1), regularItem(2, [32], 2), groupPdf],
+        (id) => itemById.get(id),
+        1,
+      ),
+      [31],
+    );
+  });
+
+  it("keeps an open request pending until the preferences MinerU target is ready", function () {
+    requestMineruManagerOpen();
+    assert.isTrue(hasPendingMineruManagerOpenRequest());
+
+    let openCount = 0;
+    registerMineruManagerOpenTarget(() => {
+      openCount += 1;
+      return true;
+    });
+
+    assert.equal(openCount, 1);
+    assert.isFalse(hasPendingMineruManagerOpenRequest());
+
+    requestMineruManagerOpen();
+    assert.equal(openCount, 2);
+    assert.isFalse(hasPendingMineruManagerOpenRequest());
   });
 
   it("keeps a selection pending until a MinerU manager target is ready", function () {

--- a/test/mineruManagerScript.test.ts
+++ b/test/mineruManagerScript.test.ts
@@ -1,8 +1,10 @@
 import { assert } from "chai";
 import {
+  calculateMineruCenteredScrollTop,
   filterMineruItemsForSearch,
   getMineruManagerActionLabels,
   getMineruParentDisplayStatus,
+  resolveMineruManagerDisplayStatus,
   shouldShowMineruManagerItem,
   type MineruParentStatusChild,
 } from "../src/modules/mineruManagerScript";
@@ -47,6 +49,75 @@ function item(
 }
 
 describe("mineruManagerScript", function () {
+  describe("resolveMineruManagerDisplayStatus", function () {
+    it("preserves runtime processing and failure without re-reading cache state", function () {
+      assert.equal(
+        resolveMineruManagerDisplayStatus("missing", "processing"),
+        "processing",
+      );
+      assert.equal(
+        resolveMineruManagerDisplayStatus("missing", "failed"),
+        "failed",
+      );
+    });
+
+    it("lets known MinerU availability win over stale failed runtime state", function () {
+      assert.equal(
+        resolveMineruManagerDisplayStatus("local", "failed"),
+        "cached",
+      );
+      assert.equal(
+        resolveMineruManagerDisplayStatus("synced", undefined),
+        "cached",
+      );
+      assert.equal(
+        resolveMineruManagerDisplayStatus("missing", undefined),
+        "idle",
+      );
+    });
+  });
+
+  describe("calculateMineruCenteredScrollTop", function () {
+    it("centers a navigation target inside the MinerU list", function () {
+      assert.equal(
+        calculateMineruCenteredScrollTop({
+          scrollTop: 200,
+          clientHeight: 400,
+          scrollHeight: 2000,
+          containerTop: 100,
+          targetTop: 900,
+          targetHeight: 30,
+        }),
+        815,
+      );
+    });
+
+    it("clamps navigation scrolling to the list boundaries", function () {
+      assert.equal(
+        calculateMineruCenteredScrollTop({
+          scrollTop: 0,
+          clientHeight: 400,
+          scrollHeight: 1800,
+          containerTop: 100,
+          targetTop: 110,
+          targetHeight: 20,
+        }),
+        0,
+      );
+      assert.equal(
+        calculateMineruCenteredScrollTop({
+          scrollTop: 1500,
+          clientHeight: 400,
+          scrollHeight: 1800,
+          containerTop: 100,
+          targetTop: 450,
+          targetHeight: 40,
+        }),
+        1400,
+      );
+    });
+  });
+
   describe("filterMineruItemsForSearch", function () {
     const items = [
       item(1, {

--- a/test/zoteroItemContextMenu.test.ts
+++ b/test/zoteroItemContextMenu.test.ts
@@ -73,18 +73,21 @@ describe("Zotero item context menu dispatch", function () {
     } as unknown as Zotero.Item;
     const pdfA = {
       id: 11,
+      libraryID: 1,
       isRegularItem: () => false,
       isAttachment: () => true,
       attachmentContentType: "application/pdf",
     } as unknown as Zotero.Item;
     const pdfB = {
       id: 12,
+      libraryID: 1,
       isRegularItem: () => false,
       isAttachment: () => true,
       attachmentContentType: "application/pdf",
     } as unknown as Zotero.Item;
     const noteAttachment = {
       id: 13,
+      libraryID: 1,
       isRegularItem: () => false,
       isAttachment: () => true,
       attachmentContentType: "text/html",
@@ -95,6 +98,7 @@ describe("Zotero item context menu dispatch", function () {
       [13, noteAttachment],
     ]);
     (globalThis as unknown as { Zotero: unknown }).Zotero = {
+      Libraries: { userLibraryID: 1 },
       Items: { get: (id: number) => items.get(id) || null },
     };
 
@@ -130,12 +134,58 @@ describe("Zotero item context menu dispatch", function () {
     const mineruCommand = registrations.find(
       ({ options }) => options.id === "llmforzotero-recognize-pdfs-with-mineru",
     )?.options;
-    assert.equal(mineruCommand?.label, "Recognize PDFs with MinerU");
+    assert.equal(mineruCommand?.label, "Open MinerU Manager");
     assert.isFunction(mineruCommand?.commandListener);
 
     mineruCommand?.commandListener?.();
 
     assert.deepEqual(requestedIds, [11, 12]);
+    assert.equal(openCount, 1);
+  });
+
+  it("opens MinerU manager even when the selected item has no PDF", function () {
+    const parentWithoutPdf = {
+      id: 20,
+      libraryID: 1,
+      isRegularItem: () => true,
+      isAttachment: () => false,
+      getAttachments: () => [],
+      getField: () => "No PDF",
+    } as unknown as Zotero.Item;
+    (globalThis as unknown as { Zotero: unknown }).Zotero = {
+      Libraries: { userLibraryID: 1 },
+      Items: { get: () => null },
+    };
+
+    const registrations: Array<{
+      options: {
+        id?: string;
+        commandListener?: () => void;
+      };
+    }> = [];
+    let openCount = 0;
+    registerZoteroItemContextMenu({
+      ztoolkit: {
+        Menu: {
+          register: (_menu: string, options: any) => {
+            registrations.push({ options });
+          },
+        },
+      } as any,
+      getSelectedItems: () => [parentWithoutPdf],
+      openStandaloneChat: () => undefined,
+      openMineruManager: () => {
+        openCount += 1;
+      },
+    });
+
+    registrations
+      .find(
+        ({ options }) =>
+          options.id === "llmforzotero-recognize-pdfs-with-mineru",
+      )
+      ?.options.commandListener?.();
+
     assert.equal(openCount, 1);
   });
 

--- a/test/zoteroItemContextMenu.test.ts
+++ b/test/zoteroItemContextMenu.test.ts
@@ -7,6 +7,10 @@ import {
   registerContextSurfaceActionTarget,
   registerZoteroItemContextMenu,
 } from "../src/modules/contextPanel/zoteroItemContextMenu";
+import {
+  clearMineruManagerNavigationForTests,
+  registerMineruManagerSelectionTarget,
+} from "../src/modules/mineruManagerNavigation";
 
 function makeItem(id: number): Zotero.Item {
   return {
@@ -21,6 +25,8 @@ function makeItem(id: number): Zotero.Item {
 describe("Zotero item context menu dispatch", function () {
   afterEach(function () {
     clearContextSurfaceActionTargetsForTests();
+    clearMineruManagerNavigationForTests();
+    delete (globalThis as unknown as { Zotero?: unknown }).Zotero;
   });
 
   it("registers the Zotero item-tree command between separators", function () {
@@ -54,6 +60,83 @@ describe("Zotero item context menu dispatch", function () {
       "Add Items as Context to LLM-for-Zotero",
     );
     assert.equal(registrations[2].options.tag, "menuseparator");
+  });
+
+  it("opens MinerU manager and preselects every PDF below the selected item", function () {
+    const parent = {
+      id: 10,
+      libraryID: 1,
+      isRegularItem: () => true,
+      isAttachment: () => false,
+      getAttachments: () => [11, 12, 13],
+      getField: () => "Parent",
+    } as unknown as Zotero.Item;
+    const pdfA = {
+      id: 11,
+      isRegularItem: () => false,
+      isAttachment: () => true,
+      attachmentContentType: "application/pdf",
+    } as unknown as Zotero.Item;
+    const pdfB = {
+      id: 12,
+      isRegularItem: () => false,
+      isAttachment: () => true,
+      attachmentContentType: "application/pdf",
+    } as unknown as Zotero.Item;
+    const noteAttachment = {
+      id: 13,
+      isRegularItem: () => false,
+      isAttachment: () => true,
+      attachmentContentType: "text/html",
+    } as unknown as Zotero.Item;
+    const items = new Map<number, Zotero.Item>([
+      [11, pdfA],
+      [12, pdfB],
+      [13, noteAttachment],
+    ]);
+    (globalThis as unknown as { Zotero: unknown }).Zotero = {
+      Items: { get: (id: number) => items.get(id) || null },
+    };
+
+    let requestedIds: readonly number[] = [];
+    registerMineruManagerSelectionTarget((attachmentIds) => {
+      requestedIds = [...attachmentIds];
+      return true;
+    });
+
+    const registrations: Array<{
+      options: {
+        id?: string;
+        label?: string;
+        commandListener?: () => void;
+      };
+    }> = [];
+    let openCount = 0;
+    registerZoteroItemContextMenu({
+      ztoolkit: {
+        Menu: {
+          register: (_menu: string, options: any) => {
+            registrations.push({ options });
+          },
+        },
+      } as any,
+      getSelectedItems: () => [parent],
+      openStandaloneChat: () => undefined,
+      openMineruManager: () => {
+        openCount += 1;
+      },
+    });
+
+    const mineruCommand = registrations.find(
+      ({ options }) => options.id === "llmforzotero-recognize-pdfs-with-mineru",
+    )?.options;
+    assert.equal(mineruCommand?.label, "Recognize PDFs with MinerU");
+    assert.isFunction(mineruCommand?.commandListener);
+
+    mineruCommand?.commandListener?.();
+
+    assert.deepEqual(requestedIds, [11, 12]);
+    assert.equal(openCount, 1);
   });
 
   it("opens standalone instead of dispatching to a mounted embedded chat surface", async function () {


### PR DESCRIPTION
## Summary

Add **Open MinerU Manager** to Zotero's item context menu. Selecting parent items or PDF attachments opens the MinerU preferences tab, selects the supported PDFs, expands their parent rows, and centers/highlights the first matching row. Existing collection, tag, and search filters are cleared so the requested rows can be shown.

Pending navigation survives initial preferences loading, and an existing manager handles later requests immediately. The manager reuses loaded cache availability and in-memory processing status when rendering status dots, avoiding repeated cache reads during navigation. Includes Chinese localization and regression coverage for PDF collection, pending/open navigation, status precedence, and bounded centered scrolling.

The manager currently displays the personal library, so group-library PDFs are not selected. The menu only opens/selects items; starting a parse still uses the existing eligibility and explicit-override flow.

## Scope

This branch is based directly on upstream `main` (`5be02f51`) and can be reviewed independently of #411. Its nine changed files contain only MinerU navigation/rendering, the item-menu/preferences entry points, localization, and related tests. Existing chat context-menu behavior is retained.

## Validation

- MinerU and item-context-menu unit suites: **181 passing** on this independent branch.
- TypeScript, changed-file Prettier/ESLint, import-cycle check, whitespace check, and production build: **pass**.
- Full unit suite: **4240 passing, 1 pending, 3 failing**. All three Windows path/fixture failures reproduce on unchanged upstream (`claudeProfileIdentity`, two `toolGuidanceContract` cases).
- `npm run test:workflow` fails before launching tests with the existing Windows `npx.cmd` / Node 25 `spawn EINVAL` issue. No fresh Zotero GUI workflow success is claimed.
- Local integration with #411's updated branch: **212 related tests passing** and a successful combined production build.
